### PR TITLE
1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 1.1.0 - 2021-10-25
+
+### Added
+- New endpoints for BSwap:
+    - `GET /sapi/v1/bswap/poolConfigure` to get pool configure
+    - `GET /sapi/v1/bswap/addLiquidityPreview` to calculate expected share amount for adding liquidity in single or dual token
+    - `GET /sapi/v1/bswap/removeLiquidityPreview` to calculate expected asset amount of single token redemption or dual token redemption
+
+- Additional properties to specify `array` type: `minItems` and `maxItems`
+- Additional format properties to specify `integer` type: `int32` and `int64`
+- Additional format properties to specify `number` type: `float` and `double`
+- Additional property `required` for response fields
+
+## 1.0.0 - 2021-09-11
+
+### Added
+- First release

--- a/spot_api.yaml
+++ b/spot_api.yaml
@@ -50,7 +50,7 @@ paths:
       description: |-
         Test connectivity to the Rest API.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Market
       responses:
@@ -66,7 +66,7 @@ paths:
       description: |-
         Test connectivity to the Rest API and get the current server time.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Market
       responses:
@@ -79,7 +79,10 @@ paths:
                 properties:
                   serverTime:
                     type: integer
+                    format: int64
                     example: 1499827319559
+                required:
+                  - serverTime
   /api/v3/exchangeInfo:
     get:
       summary: Exchange Information
@@ -88,7 +91,7 @@ paths:
         
         - If any symbol provided in either symbol or symbols do not exist, the endpoint will throw an error.
         
-        Weight: 10
+        Weight(IP): 10
       tags:
         - Market
       parameters:
@@ -107,6 +110,7 @@ paths:
                     example: UTC
                   serverTime:
                     type: integer
+                    format: int64
                     example: 1592882214236
                   rateLimits:
                     type: array
@@ -121,10 +125,17 @@ paths:
                           example: "MINUTE"
                         intervalNum:
                           type: integer
+                          format: int32
                           example: 1
                         limit:
                           type: integer
+                          format: int32
                           example: 1200
+                      required:
+                        - rateLimitType
+                        - interval
+                        - intervalNum
+                        - limit
                   exchangeFilters:
                     type: array
                     items:
@@ -145,18 +156,22 @@ paths:
                           example: "ETH"
                         baseAssetPrecision:
                           type: integer
+                          format: int32
                           example: 8
                         quoteAsset:
                           type: string
                           example: "BTC"
                         quoteAssetPrecision:
                           type: integer
+                          format: int32
                           example: 8
                         baseCommissionPrecision:
                           type: integer
+                          format: int32
                           example: 8
                         quoteCommissionPrecision:
                           type: integer
+                          format: int32
                           example: 8
                         orderTypes:
                           type: array
@@ -190,11 +205,39 @@ paths:
                               tickSize:
                                 type: string
                                 example: "0.00000100"
+                            required:
+                              - filterType
+                              - minPrice
+                              - maxPrice
+                              - tickSize
                         permissions:
                           type: array
                           items:
                             type: string
                             example: "SPOT"
+                      required:
+                        - symbol
+                        - status
+                        - baseAsset
+                        - baseAssetPrecision
+                        - quoteAsset
+                        - quoteAssetPrecision
+                        - baseCommissionPrecision
+                        - quoteCommissionPrecision
+                        - orderTypes
+                        - icebergAllowed
+                        - ocoAllowed
+                        - quoteOrderQtyMarketAllowed
+                        - isSpotTradingAllowed
+                        - isMarginTradingAllowed
+                        - filters
+                        - permissions
+                required:
+                  - timezone
+                  - serverTime
+                  - rateLimits
+                  - exchangeFilters
+                  - symbols
         '400':
           description: Bad Request
           content:
@@ -205,12 +248,12 @@ paths:
     get:
       summary: Order Book
       description: |-
-        | Limit               | Weight  |
-        | -------------       |---------|
-        | 5, 10, 20, 50, 100  | 1       |
-        | 500                 | 5       |
-        | 1000                | 10      |
-        | 5000                | 50      |
+        | Limit               | Weight(IP)  |
+        |---------------------|-------------|
+        | 5, 10, 20, 50, 100  | 1           |
+        | 500                 | 5           |
+        | 1000                | 10          |
+        | 5000                | 50          |
       tags:
         - Market
       parameters:
@@ -219,6 +262,7 @@ paths:
           in: query
           schema:
             type: integer
+            format: int32
             default: 100
             maximum: 5000
             enum: [5, 10, 20, 50, 100, 500, 1000, 5000]
@@ -233,25 +277,29 @@ paths:
                 properties:
                   lastUpdateId:
                     type: integer
-                    example: 1060776800
+                    format: int64
                   bids:
                     type: array
                     items:
-                      type: array
-                      items:
-                          type: array
-                          items:
-                            type: string
+                        type: array
+                        items:
+                          type: string
+                          minItems: 2
+                          maxItems: 2
                   asks:
                     type: array
                     items:
-                      type: array
-                      items:
-                          type: array
-                          items:
-                            type: string
+                        type: array
+                        items:
+                          type: string
+                          minItems: 2
+                          maxItems: 2
+                required:
+                  - lastUpdateId
+                  - bids
+                  - asks
               example:
-                lastUpdateId: 1060776800
+                lastUpdateId: 1027024
                 bids:
                 -
                   - "4.00000000"
@@ -272,7 +320,7 @@ paths:
       description: |-
         Get recent trades.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Market
       parameters:
@@ -299,7 +347,7 @@ paths:
       description: |-
         Get older market trades.
 
-        Weight: 5
+        Weight(IP): 5
       tags:
         - Market
       parameters:
@@ -337,7 +385,7 @@ paths:
         - If `startTime` and `endTime` are sent, time between startTime and endTime must be less than 1 hour.
         - If `fromId`, `startTime`, and `endTime` are not sent, the most recent aggregate trades will be returned.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Market
       parameters:
@@ -370,7 +418,7 @@ paths:
         
         - If `startTime` and `endTime` are not sent, the most recent klines are returned.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Market
       parameters:
@@ -393,6 +441,14 @@ paths:
               schema:
                 type: array
                 items:
+                  type: array
+                  items:
+                    oneOf:
+                      - type: integer
+                        format: int64
+                      - type: string
+                    minItems: 12
+                    maxItems: 12
                   example:
                     - 1499040000000
                     - "0.01634790"
@@ -418,7 +474,7 @@ paths:
       description: |-
         Current average price for a symbol.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Market
       parameters:
@@ -433,10 +489,14 @@ paths:
                 properties:
                   mins:
                     type: integer
+                    format: int64
                     example: 5
                   price:
                     type: string
                     example: "9.35751834"
+                required:
+                  - mins
+                  - price
         '400':
           description: Bad Request
           content:
@@ -451,9 +511,9 @@ paths:
         
         - If the symbol is not sent, tickers for all symbols will be returned in an array.
 
-        Weight:\
+        Weight(IP):\
         `1` for a single symbol;\
-        `40` when the symbol parameter is omitted
+        `40` when the symbol parameter is omitted;
 
       tags:
         - Market
@@ -482,9 +542,9 @@ paths:
         
         - If the symbol is not sent, prices for all symbols will be returned in an array.
 
-        Weight:\
+        Weight(IP):\
         `1` for a single symbol;\
-        `2` when the symbol parameter is omitted
+        `2` when the symbol parameter is omitted;
       tags:
         - Market
       parameters:
@@ -512,9 +572,9 @@ paths:
 
         - If the symbol is not sent, bookTickers for all symbols will be returned in an array.
         
-        Weight:\
-        1 for a single symbol;\
-        2 when the symbol parameter is omitted
+        Weight(IP):\
+        `1` for a single symbol;\
+        `2` when the symbol parameter is omitted;
       tags:
         - Market
       parameters:
@@ -541,7 +601,7 @@ paths:
         Test new order creation and signature/recvWindow long.
         Creates and validates a new order but does not send it into the matching engine.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Trade
       parameters:
@@ -589,7 +649,7 @@ paths:
         - Either `orderId` or `origClientOrderId` must be sent.
         - For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.
 
-        Weight: 2
+        Weight(IP): 2
       tags:
         - Trade
       parameters:
@@ -640,7 +700,7 @@ paths:
         - Price below market price: `STOP_LOSS` `SELL`, `TAKE_PROFIT` `BUY`
 
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Trade
       parameters:
@@ -689,7 +749,7 @@ paths:
 
         Either `orderId` or `origClientOrderId` must be sent.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Trade
       parameters:
@@ -727,9 +787,9 @@ paths:
       description: |-
         Get all open orders on a symbol. Careful when accessing this with no symbol.
 
-        Weight:\
+        Weight(IP):\
         `3` for a single symbol;\
-        `40` when the symbol parameter is omitted
+        `40` when the symbol parameter is omitted;
       tags:
         - Trade
       parameters:
@@ -766,7 +826,7 @@ paths:
         Cancels all active orders on a symbol.\
         This includes OCO orders.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Trade
       parameters:
@@ -784,7 +844,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/order'
+                  anyOf:
+                    - $ref: '#/components/schemas/order'
+                    - $ref: '#/components/schemas/ocoOrder'
         '400':
           description: Bad Request
           content:
@@ -807,7 +869,7 @@ paths:
         - For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.
         - If `startTime` and/or `endTime` provided, `orderId` is not required
 
-        Weight: 10
+        Weight(IP): 10
       tags:
         - Trade
       parameters:
@@ -857,7 +919,7 @@ paths:
         - Order Rate Limit
             - `OCO` counts as 2 orders against the order rate limit.
             
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Trade
       parameters:
@@ -890,6 +952,7 @@ paths:
                 properties:
                   orderListId:
                     type: integer
+                    format: int64
                     example: 0
                   contingencyType:
                     type: string
@@ -905,6 +968,7 @@ paths:
                     example: "JYVpp3F0f5CAG15DhtrqLp"
                   transactionTime:
                     type: integer
+                    format: int64
                     example: 1563417480525
                   symbol:
                     type: string
@@ -912,13 +976,19 @@ paths:
                   orders:
                     type: array
                     items:
+                      type: object
                       properties:
                         symbol:
                           type: string
                         orderId:
                           type: integer
+                          format: int64
                         clientOrderId:
                           type: string
+                      required:
+                        - symbol
+                        - orderId
+                        - clientOrderId
                       example:
                         - symbol: "LTCBTC"
                           orderId: 2
@@ -935,12 +1005,15 @@ paths:
                           type: string
                         orderId: 
                           type: integer
+                          format: int64
                         orderListId: 
                           type: integer
+                          format: int64
                         clientOrderId: 
                           type: string
                         transactTime: 
                           type: integer
+                          format: int64
                         price: 
                           type: string
                         origQty: 
@@ -959,6 +1032,21 @@ paths:
                           type: string
                         stopPrice: 
                           type: string
+                      required:
+                        - symbol
+                        - orderId
+                        - orderListId
+                        - clientOrderId
+                        - transactTime
+                        - price
+                        - origQty
+                        - executedQty
+                        - cummulativeQuoteQty
+                        - status
+                        - timeInForce
+                        - type
+                        - side
+                        - stopPrice
                     example:
                       - symbol: "LTCBTC"
                         orderId: 2
@@ -987,6 +1075,16 @@ paths:
                         timeInForce: "GTC"
                         type: "LIMIT_MAKER"
                         side: "BUY"
+                required:
+                  - orderListId
+                  - contingencyType
+                  - listStatusType
+                  - listOrderStatus
+                  - listClientOrderId
+                  - transactionTime
+                  - symbol
+                  - orders
+                  - orderReports
         '400':
           description: Bad Request
           content:
@@ -1005,7 +1103,7 @@ paths:
       description: |-
         Retrieves a specific OCO based on provided optional parameters
 
-        Weight: 2
+        Weight(IP): 2
       tags:
         - Trade
       parameters:
@@ -1024,36 +1122,39 @@ paths:
               schema:
                 type: object
                 properties:
-                  orderListId: 
+                  orderListId:
                     type: integer
+                    format: int64
                     example: 27
-                  contingencyType: 
+                  contingencyType:
                     type: string
                     example: "OCO"
-                  listStatusType: 
+                  listStatusType:
                     type: string
                     example: "EXEC_STARTED"
-                  listOrderStatus: 
+                  listOrderStatus:
                     type: string
                     example: "EXECUTING"
-                  listClientOrderId: 
+                  listClientOrderId:
                     type: string
                     example: "h2USkA5YQpaXHPIrkd96xE"
-                  transactionTime: 
+                  transactionTime:
                     type: integer
+                    format: int64
                     example: 1565245656253
-                  symbol: 
+                  symbol:
                     type: string
                     example: "LTCBTC"
-                  orders: 
+                  orders:
                     type: array
-                    items: 
+                    items:
                       type: object
-                      properties: 
+                      properties:
                         symbol: 
                           type: string
                         orderId: 
                           type: integer
+                          format: int64
                         clientOrderId: 
                           type: string
                       example:
@@ -1063,6 +1164,19 @@ paths:
                         - symbol: "LTCBTC"
                           orderId: 5
                           clientOrderId: "ARzZ9I00CPM8i3NhmU9Ega"
+                      required:
+                          - symbol
+                          - orderId
+                          - clientOrderId
+                required:
+                  - orderListId
+                  - contingencyType
+                  - listStatusType
+                  - listOrderStatus
+                  - listClientOrderId
+                  - transactionTime
+                  - symbol
+                  - orders
         '400':
           description: Bad Request
           content:
@@ -1082,7 +1196,7 @@ paths:
 
         Canceling an individual leg will cancel the entire OCO
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Trade
       parameters:
@@ -1101,108 +1215,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  orderListId: 
-                    type: integer
-                    example: 0
-                  contingencyType: 
-                    type: string
-                    example: "OCO"
-                  listStatusType: 
-                    type: string
-                    example: "ALL_DONE"
-                  listOrderStatus: 
-                    type: string
-                    example: "ALL_DONE"
-                  listClientOrderId: 
-                    type: string
-                    example: "C3wyj4WVEktd7u9aVBRXcN"
-                  transactionTime: 
-                    type: integer
-                    example: 1574040868128
-                  symbol: 
-                    type: string
-                    example: "LTCBTC"
-                  orders: 
-                    type: array
-                    items: 
-                      type: object
-                      properties: 
-                        symbol: 
-                          type: string
-                        orderId: 
-                          type: integer
-                        clientOrderId: 
-                          type: string
-                    example:
-                      - symbol: "LTCBTC"
-                        orderId: 2
-                        clientOrderId: "pO9ufTiFGg3nw2fOdgeOXa"
-                      - symbol: "LTCBTC"
-                        orderId: 3
-                        clientOrderId: "TXOvglzXuaubXAaENpaRCB"
-                  orderReports: 
-                    type: array
-                    items: 
-                      type: object
-                      properties: 
-                        symbol: 
-                          type: string
-                        origClientOrderId:
-                          type: string
-                        orderId: 
-                          type: integer
-                        orderListId: 
-                          type: integer
-                        clientOrderId: 
-                          type: string
-                        price: 
-                          type: string
-                        origQty: 
-                          type: string
-                        executedQty: 
-                          type: string
-                        cummulativeQuoteQty: 
-                          type: string
-                        status: 
-                          type: string
-                        timeInForce: 
-                          type: string
-                        type: 
-                          type: string
-                        side: 
-                          type: string
-                        stopPrice: 
-                          type: string
-                    example:
-                      - symbol: "LTCBTC"
-                        origClientOrderId: "pO9ufTiFGg3nw2fOdgeOXa"
-                        orderId: 2
-                        orderListId: 0
-                        clientOrderId: "unfWT8ig8i0uj6lPuYLez6"
-                        price: "1.00000000"
-                        origQty: "10.00000000"
-                        executedQty: "0.00000000"
-                        cummulativeQuoteQty: "0.00000000"
-                        status: "CANCELED"
-                        timeInForce: "GTC"
-                        type: "STOP_LOSS_LIMIT"
-                        side: "SELL"
-                        stopPrice: "1.00000000"
-                      - symbol: "LTCBTC"
-                        origClientOrderId: "TXOvglzXuaubXAaENpaRCB"
-                        orderId: 3
-                        orderListId: 0
-                        clientOrderId: "unfWT8ig8i0uj6lPuYLez6"
-                        price: "3.00000000"
-                        origQty: "10.00000000"
-                        executedQty: "0.00000000"
-                        cummulativeQuoteQty: "0.00000000"
-                        status: "CANCELED"
-                        timeInForce: "GTC"
-                        type: "LIMIT_MAKER"
-                        side: "SELL"
+                $ref: '#/components/schemas/ocoOrder'
         '400':
           description: Bad Request
           content:
@@ -1221,7 +1234,7 @@ paths:
       description: |-
         Retrieves all OCO based on provided optional parameters
 
-        Weight: 10
+        Weight(IP): 10
       tags:
         - Trade
       parameters:
@@ -1246,6 +1259,7 @@ paths:
                   properties:
                     orderListId: 
                       type: integer
+                      format: int64
                       example: 29
                     contingencyType: 
                       type: string
@@ -1261,6 +1275,7 @@ paths:
                       example: "amEEAXryFzFwYF1FeRpUoZ"
                     transactionTime: 
                       type: integer
+                      format: int64
                       example: 1565245913483
                     symbol: 
                       type: string
@@ -1276,6 +1291,7 @@ paths:
                             type: string
                           orderId: 
                             type: integer
+                            format: int64
                           clientOrderId: 
                             type: string
                         example:
@@ -1285,6 +1301,20 @@ paths:
                           - symbol: "LTCBTC"
                             orderId: 5
                             clientOrderId: "Jr1h6xirOxgeJOUuYQS7V3"
+                        required:
+                            - symbol
+                            - orderId
+                            - clientOrderId
+                  required:
+                      - orderListId
+                      - contingencyType
+                      - listStatusType
+                      - listOrderStatus
+                      - listClientOrderId
+                      - transactionTime
+                      - symbol
+                      - isIsolated
+                      - orders
         '400':
           description: Bad Request
           content:
@@ -1300,7 +1330,7 @@ paths:
   /api/v3/openOrderList:
     get:
       summary: Query Open OCO (USER_DATA)
-      description: 'Weight: 3'
+      description: 'Weight(IP): 3'
       tags:
         - Trade
       parameters:
@@ -1321,6 +1351,7 @@ paths:
                   properties:
                     orderListId: 
                       type: integer
+                      format: int64
                       example: 31
                     contingencyType: 
                       type: string
@@ -1336,6 +1367,7 @@ paths:
                       example: "wuB13fmulKj3YjdqWEcsnp"
                     transactionTime: 
                       type: integer
+                      format: int64
                       example: 1565246080644
                     symbol: 
                       type: string
@@ -1349,8 +1381,13 @@ paths:
                             type: string
                           orderId: 
                             type: integer
+                            format: int64
                           clientOrderId: 
                             type: string
+                        required:
+                            - symbol
+                            - orderId
+                            - clientOrderId
                         example:
                           - symbol: "LTCBTC"
                             orderId: 4
@@ -1358,6 +1395,15 @@ paths:
                           - symbol: "LTCBTC"
                             orderId: 5
                             clientOrderId: "Cv1SnyPD3qhqpbjpYEHbd2"
+                  required:
+                      - orderListId
+                      - contingencyType
+                      - listStatusType
+                      - listOrderStatus
+                      - listClientOrderId
+                      - transactionTime
+                      - symbol
+                      - orders
         '400':
           description: Bad Request
           content:
@@ -1376,7 +1422,7 @@ paths:
       description: |-
         Get current account information.
 
-        Weight: 10
+        Weight(IP): 10
       tags:
         - Trade
       parameters:
@@ -1412,7 +1458,7 @@ paths:
 
         If `fromId` is set, it will get id >= that `fromId`. Otherwise most recent orders are returned.
 
-        Weight: 10
+        Weight(IP): 10
       tags:
         - Trade
       parameters:
@@ -1422,6 +1468,7 @@ paths:
           description: This can only be used in combination with symbol.
           schema:
             type: integer
+            format: int64
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
         - $ref: '#/components/parameters/fromId'
@@ -1458,7 +1505,7 @@ paths:
       description: |-
         Execute transfer between spot account and cross margin account.
 
-        Weight: 1
+        Weight(IP): 600
       tags:
         - Margin
       parameters:
@@ -1471,6 +1518,7 @@ paths:
             2 -> transfer from margin account to main account
           schema:
             type: integer
+            format: int32
             enum: [1,2]
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -1503,7 +1551,7 @@ paths:
         - Returns data for last 7 days by default
         - Set `archived` to `true` to query data from 6 months ago
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Margin
       parameters:
@@ -1531,6 +1579,37 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  rows: 
+                    type: array
+                    items: 
+                      type: object
+                      properties: 
+                        amount: 
+                          type: string
+                        asset: 
+                          type: string
+                        status: 
+                          type: string
+                        timestamp: 
+                          type: integer
+                          format: int64
+                        txId: 
+                          type: integer
+                          format: int64
+                        type: 
+                          type: string
+                      required:
+                          - amount
+                          - asset
+                          - status
+                          - timestamp
+                          - txId
+                          - type
+                  total: 
+                    type: integer
+                    format: int32
+                    example: 3
                 example:
                   rows:
                     -
@@ -1541,6 +1620,9 @@ paths:
                       txId: 5240372201
                       type: "ROLL_IN"
                   total: 1
+                required:
+                    - rows
+                    - total
         '400':
           description: Bad Request
           content:
@@ -1562,7 +1644,7 @@ paths:
         - If "isIsolated" = "TRUE", "symbol" must be sent
         - "isIsolated" = "FALSE" for crossed margin loan
         
-        Weight: 1
+        Weight(UID): 3000
       tags:
         - Margin
       parameters:
@@ -1595,14 +1677,14 @@ paths:
                 schema:
                   $ref: '#/components/schemas/error'
     get:
-      summary: Query Load Record (USER_DATA)
+      summary: Query Loan Record (USER_DATA)
       description: |-
         - `txId` or `startTime` must be sent. `txId` takes precedence.
         - Response in descending order
         - If `isolatedSymbol` is not sent, crossed margin data will be returned
         - Set `archived` to `true` to query data from 6 months ago
 
-        Weight: 1
+        Weight(IP): 10
       tags:
         - Margin
       parameters:
@@ -1613,6 +1695,7 @@ paths:
           description: the tranId in  `POST /sapi/v1/margin/loan`
           schema:
             type: integer
+            format: int64
             example: 123456789
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
@@ -1626,11 +1709,44 @@ paths:
         - ApiKeyAuth: []
       responses:
         '200':
-          description: Load records
+          description: Loan records
           content:
             application/json:
               schema:
                 type: object
+                properties:
+                  rows:
+                    type: array
+                    items: 
+                      type: object
+                      properties: 
+                        isolatedSymbol: 
+                          type: string
+                        txId: 
+                          type: integer
+                          format: int64
+                        asset: 
+                          type: string
+                        principal: 
+                          type: string
+                        timestamp: 
+                          type: integer
+                          format: int64
+                        status: 
+                          type: string
+                      required:
+                          - isolatedSymbol
+                          - txId
+                          - asset
+                          - principal
+                          - timestamp
+                          - status
+                  total: 
+                    type: integer
+                    format: int32
+                required:
+                    - rows
+                    - total
                 example:
                   rows:
                     -
@@ -1662,7 +1778,7 @@ paths:
         - If "isIsolated" = "TRUE", "symbol" must be sent
         - "isIsolated" = "FALSE" for crossed margin repay
 
-        Weight: 1
+        Weight(IP): 3000
       tags:
         - Margin
       parameters:
@@ -1702,7 +1818,7 @@ paths:
         - If `isolatedSymbol` is not sent, crossed margin data will be returned
         - Set `archived` to `true` to query data from 6 months ago
         
-        Weight: 1
+        Weight(IP): 10
       tags:
         - Margin
       parameters:
@@ -1713,6 +1829,7 @@ paths:
           description: the tranId in  `POST /sapi/v1/margin/repay`
           schema:
             type: integer
+            format: int64
             example: 2970933056
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
@@ -1762,13 +1879,28 @@ paths:
                           description: One of PENDING (pending execution), CONFIRMED (successfully execution), FAILED (execution failed, nothing happened to your account)
                         timestamp:
                           type: integer
+                          format: int64
                           example: 1563438204000
                         txId:
                           type: integer
+                          format: int64
                           example: 2970933056
+                      required:
+                          - isolatedSymbol
+                          - amount
+                          - asset
+                          - interest
+                          - principal
+                          - status
+                          - timestamp
+                          - txId
                   total:
                     type: integer
+                    format: int32
                     example: 1
+                required:
+                    - rows
+                    - total
         '400':
           description: Bad Request
           content:
@@ -1784,7 +1916,7 @@ paths:
   /sapi/v1/margin/asset:
     get:
       summary: Query Margin Asset (MARKET_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Margin
       parameters:
@@ -1816,6 +1948,13 @@ paths:
                   userMinRepay:
                     type: string
                     example: "0.00000000"
+                required:
+                    - assetFullName
+                    - assetName
+                    - isBorrowable
+                    - isMortgageable
+                    - userMinBorrow
+                    - userMinRepay
         '400':
           description: Bad Request
           content:
@@ -1825,7 +1964,7 @@ paths:
   /sapi/v1/margin/pair:
     get:
       summary: Query Cross Margin Pair (MARKET_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Margin
       parameters:
@@ -1842,6 +1981,7 @@ paths:
                 properties:
                   id:
                     type: integer
+                    format: int64
                     example: 323355778339572400
                   symbol:
                     type: string
@@ -1858,6 +1998,14 @@ paths:
                     type: boolean
                   isSellAllowed:
                     type: boolean
+                required:
+                    - id
+                    - symbol
+                    - base
+                    - quote
+                    - isMarginTrade
+                    - isBuyAllowed
+                    - isSellAllowed
         '400':
           description: Bad Request
           content:
@@ -1867,7 +2015,7 @@ paths:
   /sapi/v1/margin/allAssets:
     get:
       summary: Get All Margin Assets (MARKET_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Margin
       security:
@@ -1898,6 +2046,13 @@ paths:
                     userMinRepay:
                       type: string
                       example: "0.00000000"
+                  required:
+                      - assetFullName
+                      - assetName
+                      - isBorrowable
+                      - isMortgageable
+                      - userMinBorrow
+                      - userMinRepay
         '400':
           description: Bad Request
           content:
@@ -1907,7 +2062,7 @@ paths:
   /sapi/v1/margin/allPairs:
     get:
       summary: Get All Cross Margin Pairs (MARKET_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Margin
       security:
@@ -1927,6 +2082,7 @@ paths:
                       example: "BNB"
                     id:
                       type: integer
+                      format: int64
                       example: 351637150141315861
                     isBuyAllowed:
                       type: boolean
@@ -1940,6 +2096,14 @@ paths:
                     symbol:
                       type: string
                       example: "BNBBTC"
+                  required:
+                      - base
+                      - id
+                      - isBuyAllowed
+                      - isMarginTrade
+                      - isSellAllowed
+                      - quote
+                      - symbol
         '400':
           description: Bad Request
           content:
@@ -1949,7 +2113,7 @@ paths:
   /sapi/v1/margin/priceIndex:
     get:
       summary: Query Margin PriceIndex (MARKET_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Margin
       parameters:
@@ -1966,6 +2130,7 @@ paths:
                 properties:
                   calcTime:
                     type: integer
+                    format: int64
                     example: 1562046418000
                   price:
                     type: string
@@ -1973,6 +2138,10 @@ paths:
                   symbol:
                     type: string
                     example: "BNBBTC"
+                required:
+                    - calcTime
+                    - price
+                    - symbol
         '400':
           description: Bad Request
           content:
@@ -1986,7 +2155,7 @@ paths:
         - Either `orderId` or `origClientOrderId` must be sent.
         - For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.
 
-        Weight: 1
+        Weight(IP): 10
       tags:
         - Margin
       parameters:
@@ -2023,7 +2192,7 @@ paths:
       description: |-
         Post a new order for margin account.
 
-        Weight: 1
+        Weight(UID): 6
       tags:
         - Margin
       parameters:
@@ -2074,7 +2243,7 @@ paths:
 
         Either `orderId` or `origClientOrderId` must be sent.
 
-        Weight: 1
+        Weight(IP): 10
       tags:
         - Margin
       parameters:
@@ -2120,7 +2289,7 @@ paths:
           - `PERIODIC_CONVERTED` interest charged per hour converted into BNB
           - `ON_BORROW_CONVERTED` first interest charged on borrow converted into BNB
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Margin
       parameters:
@@ -2160,6 +2329,7 @@ paths:
                           example: "0.01866667"
                         interestAccuredTime:
                           type: integer
+                          format: int64
                           example: 1566813600
                         interestRate:
                           type: string
@@ -2170,9 +2340,21 @@ paths:
                         type:
                           type: string
                           example: "ON_BORROW"
+                      required:
+                          - isolatedSymbol
+                          - asset
+                          - interest
+                          - interestAccuredTime
+                          - interestRate
+                          - principal
+                          - type
                   total:
                     type: integer
+                    format: int32
                     example: 1
+                required:
+                    - rows
+                    - total
         '400':
           description: Bad Request
           content:
@@ -2191,7 +2373,7 @@ paths:
       description: |-
         - Response in descending order
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Margin
       parameters:
@@ -2212,20 +2394,66 @@ paths:
             application/json:
               schema:
                 type: object
-              example:
-                rows:
-                  -
-                    avgPrice: "0.00388359"
-                    executedQty: "31.39000000"
-                    orderId: 180015097
-                    price: "0.00388110"
-                    qty: "31.39000000"
-                    side: "SELL"
-                    symbol: "BNBBTC"
-                    timeInForce: "GTC"
-                    isIsolated: true
-                    updatedTime: 1558941374745
-                total: 1
+                properties:
+                  rows: 
+                    type: array
+                    items: 
+                      type: object
+                      properties: 
+                        avgPrice: 
+                          type: string
+                        executedQty: 
+                          type: string
+                        orderId: 
+                          type: integer
+                          format: int64
+                        price: 
+                          type: string
+                        qty: 
+                          type: string
+                        side: 
+                          type: string
+                        symbol: 
+                          type: string
+                        timeInForce: 
+                          type: string
+                        isIsolated: 
+                          type: boolean
+                        updatedTime: 
+                          type: integer
+                          format: int64
+                      required:
+                          - avgPrice
+                          - executedQty
+                          - orderId
+                          - price
+                          - qty
+                          - side
+                          - symbol
+                          - timeInForce
+                          - isIsolated
+                          - updatedTime
+                  total: 
+                    type: integer
+                    format: int32
+                    example: 1
+                required:
+                    - rows
+                    - total
+                example:
+                  rows:
+                    -
+                      avgPrice: "0.00388359"
+                      executedQty: "31.39000000"
+                      orderId: 180015097
+                      price: "0.00388110"
+                      qty: "31.39000000"
+                      side: "SELL"
+                      symbol: "BNBBTC"
+                      timeInForce: "GTC"
+                      isIsolated: true
+                      updatedTime: 1558941374745
+                  total: 1
         '400':
           description: Bad Request
           content:
@@ -2241,7 +2469,7 @@ paths:
   /sapi/v1/margin/account:
     get:
       summary: Query Cross Margin Account Details (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Margin
       parameters:
@@ -2299,6 +2527,22 @@ paths:
                         netAsset:
                           type: string
                           example: "0.00499500"
+                      required:
+                          - asset
+                          - borrowed
+                          - free
+                          - interest
+                          - locked
+                          - netAsset
+                required:
+                    - borrowEnabled
+                    - marginLevel
+                    - totalAssetOfBtc
+                    - totalLiabilityOfBtc
+                    - totalNetAssetOfBtc
+                    - tradeEnabled
+                    - transferEnabled
+                    - userAssets
         '400':
           description: Bad Request
           content:
@@ -2313,13 +2557,13 @@ paths:
                 $ref: '#/components/schemas/error'
   /sapi/v1/margin/openOrders:
     get:
-      summary: Query Margin Account's Open Order (USER_DATA)
+      summary: Query Margin Account's Open Orders (USER_DATA)
       description: |-
         - If the `symbol` is not sent, orders for all symbols will be returned in an array.
         - When all symbols are returned, the number of requests counted against the rate limiter is equal to the number of symbols currently trading on the exchange
         - If isIsolated ="TRUE", symbol must be sent.
 
-        Weight: 1
+        Weight(IP): 10
       tags:
         - Margin
       parameters:
@@ -2357,7 +2601,7 @@ paths:
         - Cancels all active orders on a symbol for margin account.
         - This includes OCO orders.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Margin
       parameters:
@@ -2376,7 +2620,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/canceledMarginOrderDetail'
+                  anyOf:
+                    - $ref: '#/components/schemas/canceledMarginOrderDetail'
+                    - $ref: '#/components/schemas/marginOcoOrder'
         '400':
           description: Bad Request
           content:
@@ -2396,7 +2642,7 @@ paths:
         - If `orderId` is set, it will get orders >= that orderId. Otherwise most recent orders are returned.
         - For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.
 
-        Weight: 1
+        Weight(IP): 200
         
         Request Limit: 60 times/min per IP
       tags:
@@ -2449,7 +2695,7 @@ paths:
         - Order Rate Limit
           - OCO counts as 2 orders against the order rate limit.
         
-        Weight: 1
+        Weight(UID): 6
       tags:
         - Margin
       parameters:
@@ -2483,6 +2729,7 @@ paths:
                 properties:
                   orderListId: 
                     type: integer
+                    format: int64
                     example: 0
                   contingencyType: 
                     type: string
@@ -2498,6 +2745,7 @@ paths:
                     example: "JYVpp3F0f5CAG15DhtrqLp"
                   transactionTime: 
                     type: integer
+                    format: int64
                     example: 1563417480525
                   symbol: 
                     type: string
@@ -2522,8 +2770,13 @@ paths:
                           type: string
                         orderId: 
                           type: integer
+                          format: int64
                         clientOrderId: 
                           type: string
+                      required:
+                          - symbol
+                          - orderId
+                          - clientOrderId
                     example:
                       - symbol: "LTCBTC"
                         orderId: 2
@@ -2540,12 +2793,15 @@ paths:
                           type: string
                         orderId: 
                           type: integer
+                          format: int64
                         orderListId: 
                           type: integer
+                          format: int64
                         clientOrderId: 
                           type: string
                         transactTime: 
                           type: integer
+                          format: int64
                         price: 
                           type: string
                         origQty: 
@@ -2564,6 +2820,21 @@ paths:
                           type: string
                         stopPrice: 
                           type: string
+                      required:
+                          - symbol
+                          - orderId
+                          - orderListId
+                          - clientOrderId
+                          - transactTime
+                          - price
+                          - origQty
+                          - executedQty
+                          - cummulativeQuoteQty
+                          - status
+                          - timeInForce
+                          - type
+                          - side
+                          - stopPrice
                     example:
                       - symbol: "LTCBTC"
                         orderId: 2
@@ -2592,6 +2863,19 @@ paths:
                         timeInForce: "GTC"
                         type: "LIMIT_MAKER"
                         side: "BUY"
+                required:
+                    - orderListId
+                    - contingencyType
+                    - listStatusType
+                    - listOrderStatus
+                    - listClientOrderId
+                    - transactionTime
+                    - symbol
+                    - marginBuyBorrowAmount
+                    - marginBuyBorrowAsset
+                    - isIsolated
+                    - orders
+                    - orderReports
         '400':
           description: Bad Request
           content:
@@ -2612,7 +2896,7 @@ paths:
         
         - Either `orderListId` or `origClientOrderId` must be provided
         
-        Weight: 2
+        Weight(IP): 10
       tags:
         - Margin
       parameters:
@@ -2639,6 +2923,7 @@ paths:
                 properties:
                   orderListId: 
                     type: integer
+                    format: int64
                     example: 27
                   contingencyType: 
                     type: string
@@ -2654,6 +2939,7 @@ paths:
                     example: "h2USkA5YQpaXHPIrkd96xE"
                   transactionTime: 
                     type: integer
+                    format: int64
                     example: 1565245656253
                   symbol: 
                     type: string
@@ -2670,6 +2956,7 @@ paths:
                           type: string
                         orderId: 
                           type: integer
+                          format: int64
                         clientOrderId: 
                           type: string
                       example:
@@ -2679,6 +2966,20 @@ paths:
                         - symbol: "LTCBTC"
                           orderId: 5
                           clientOrderId: "ARzZ9I00CPM8i3NhmU9Ega"
+                      required:
+                          - symbol
+                          - orderId
+                          - clientOrderId
+                required:
+                    - orderListId
+                    - contingencyType
+                    - listStatusType
+                    - listOrderStatus
+                    - listClientOrderId
+                    - transactionTime
+                    - symbol
+                    - isIsolated
+                    - orders
         '400':
           description: Bad Request
           content:
@@ -2699,7 +3000,7 @@ paths:
         - Canceling an individual leg will cancel the entire OCO
         - Either `orderListId` or `listClientOrderId` must be provided
         
-        Weight: 1
+        Weight(UID): 1
       tags:
         - Margin
       parameters:
@@ -2719,111 +3020,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  orderListId: 
-                    type: integer
-                    example: 0
-                  contingencyType: 
-                    type: string
-                    example: "OCO"
-                  listStatusType: 
-                    type: string
-                    example: "ALL_DONE"
-                  listOrderStatus: 
-                    type: string
-                    example: "ALL_DONE"
-                  listClientOrderId: 
-                    type: string
-                    example: "C3wyj4WVEktd7u9aVBRXcN"
-                  transactionTime: 
-                    type: integer
-                    example: 1574040868128
-                  symbol: 
-                    type: string
-                    example: "LTCBTC"
-                  isIsolated: 
-                    type: boolean
-                    example: false
-                  orders: 
-                    type: array
-                    items: 
-                      type: object
-                      properties: 
-                        symbol: 
-                          type: string
-                        orderId: 
-                          type: integer
-                        clientOrderId: 
-                          type: string
-                    example:
-                      - symbol: "LTCBTC"
-                        orderId: 2
-                        clientOrderId: "pO9ufTiFGg3nw2fOdgeOXa"
-                      - symbol: "LTCBTC"
-                        orderId: 3
-                        clientOrderId: "TXOvglzXuaubXAaENpaRCB"
-                  orderReports: 
-                    type: array
-                    items: 
-                      type: object
-                      properties: 
-                        symbol: 
-                          type: string
-                        origClientOrderId:
-                          type: string
-                        orderId: 
-                          type: integer
-                        orderListId: 
-                          type: integer
-                        clientOrderId: 
-                          type: string
-                        price: 
-                          type: string
-                        origQty: 
-                          type: string
-                        executedQty: 
-                          type: string
-                        cummulativeQuoteQty: 
-                          type: string
-                        status: 
-                          type: string
-                        timeInForce: 
-                          type: string
-                        type: 
-                          type: string
-                        side: 
-                          type: string
-                        stopPrice: 
-                          type: string
-                    example:
-                      - symbol: "LTCBTC"
-                        origClientOrderId: "pO9ufTiFGg3nw2fOdgeOXa"
-                        orderId: 2
-                        orderListId: 0
-                        clientOrderId: "unfWT8ig8i0uj6lPuYLez6"
-                        price: "1.00000000"
-                        origQty: "10.00000000"
-                        executedQty: "0.00000000"
-                        cummulativeQuoteQty: "0.00000000"
-                        status: "CANCELED"
-                        timeInForce: "GTC"
-                        type: "STOP_LOSS_LIMIT"
-                        side: "SELL"
-                        stopPrice: "1.00000000"
-                      - symbol: "LTCBTC"
-                        origClientOrderId: "TXOvglzXuaubXAaENpaRCB"
-                        orderId: 3
-                        orderListId: 0
-                        clientOrderId: "unfWT8ig8i0uj6lPuYLez6"
-                        price: "3.00000000"
-                        origQty: "10.00000000"
-                        executedQty: "0.00000000"
-                        cummulativeQuoteQty: "0.00000000"
-                        status: "CANCELED"
-                        timeInForce: "GTC"
-                        type: "LIMIT_MAKER"
-                        side: "SELL"
+                $ref: '#/components/schemas/marginOcoOrder'
         '400':
           description: Bad Request
           content:
@@ -2842,7 +3039,7 @@ paths:
       description: |-
         Retrieves all OCO for a specific margin account based on provided optional parameters
         
-        Weight: 10
+        Weight(IP): 200
       tags:
         - Margin
       parameters:
@@ -2864,6 +3061,7 @@ paths:
           description: 'Default Value: 500; Max Value: 1000'
           schema:
             type: integer
+            format: int32
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
         - $ref: '#/components/parameters/signature'
@@ -2881,6 +3079,7 @@ paths:
                   properties:
                     orderListId: 
                       type: integer
+                      format: int64
                       example: 29
                     contingencyType: 
                       type: string
@@ -2896,6 +3095,7 @@ paths:
                       example: "amEEAXryFzFwYF1FeRpUoZ"
                     transactionTime: 
                       type: integer
+                      format: int64
                       example: 1565245913483
                     symbol: 
                       type: string
@@ -2911,8 +3111,13 @@ paths:
                             type: string
                           orderId: 
                             type: integer
+                            format: int64
                           clientOrderId: 
                             type: string
+                        required:
+                            - symbol
+                            - orderId
+                            - clientOrderId
                         example:
                           - symbol: "LTCBTC"
                             orderId: 4
@@ -2920,6 +3125,16 @@ paths:
                           - symbol: "LTCBTC"
                             orderId: 5
                             clientOrderId: "Jr1h6xirOxgeJOUuYQS7V3"
+                  required:
+                      - orderListId
+                      - contingencyType
+                      - listStatusType
+                      - listOrderStatus
+                      - listClientOrderId
+                      - transactionTime
+                      - symbol
+                      - isIsolated
+                      - orders
         '400':
           description: Bad Request
           content:
@@ -2935,7 +3150,7 @@ paths:
   /sapi/v1/margin/openOrderList:
     get:
       summary: Query Margin Account's Open OCO (USER_DATA)
-      description: 'Weight: 3'
+      description: 'Weight(IP): 10'
       tags:
         - Margin
       parameters:
@@ -2962,6 +3177,7 @@ paths:
                   properties:
                     orderListId: 
                       type: integer
+                      format: int64
                       example: 31
                     contingencyType: 
                       type: string
@@ -2977,6 +3193,7 @@ paths:
                       example: "wuB13fmulKj3YjdqWEcsnp"
                     transactionTime: 
                       type: integer
+                      format: int64
                       example: 1565246080644
                     symbol: 
                       type: string
@@ -2993,8 +3210,13 @@ paths:
                             type: string
                           orderId: 
                             type: integer
+                            format: int64
                           clientOrderId: 
                             type: string
+                        required:
+                            - symbol
+                            - orderId
+                            - clientOrderId
                         example:
                           - symbol: "LTCBTC"
                             orderId: 4
@@ -3002,6 +3224,16 @@ paths:
                           - symbol: "LTCBTC"
                             orderId: 5
                             clientOrderId: "Cv1SnyPD3qhqpbjpYEHbd2"
+                  required:
+                      - orderListId
+                      - contingencyType
+                      - listStatusType
+                      - listOrderStatus
+                      - listClientOrderId
+                      - transactionTime
+                      - symbol
+                      - isIsolated
+                      - orders
         '400':
           description: Bad Request
           content:
@@ -3020,7 +3252,7 @@ paths:
       description: |-
         - If `fromId` is set, it will get orders >= that `fromId`. Otherwise most recent trades are returned.
 
-        Weight: 1
+        Weight(IP): 10
 
       tags:
         - Margin
@@ -3064,7 +3296,7 @@ paths:
         - If `isolatedSymbol` is not sent, crossed margin data will be sent.
         - `borrowLimit` is also available from https://www.binance.com/en/margin-fee
         
-        Weight: 5
+        Weight(IP): 50
       tags:
         - Margin
       parameters:
@@ -3091,6 +3323,9 @@ paths:
                     type: string
                     example: "60"
                     description: max borrowable amount limited by the account level
+                required:
+                    - amount
+                    - borrowLimit
         '400':
           description: Bad Request
           content:
@@ -3109,7 +3344,7 @@ paths:
       description: |-
         - If `isolatedSymbol` is not sent, crossed margin data will be sent.
         
-        Weight: 5
+        Weight(IP): 50
       tags:
         - Margin
       parameters:
@@ -3127,8 +3362,19 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  amount:
+                    type: string
+                    description: "Account's currently max borrowable amount with sufficient system availability"
+                  borrowLimit:
+                    type: string
+                    description: "Max borrowable amount limited by the account level"
                 example:
                   amount: "1.69248805"
+                  borrowLimit: "60"
+                required:
+                    - amount
+                    - borrowLimit
         '400':
           description: Bad Request
           content:
@@ -3144,7 +3390,7 @@ paths:
   /sapi/v1/margin/isolated/transfer:
     get:
       summary: Get Isolated Margin Transfer History (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Margin
       parameters:
@@ -3181,8 +3427,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
     post:
-      summary: Isolated Margin Account Transfer (USER_DATA)
-      description: 'Weight: 1'
+      summary: Isolated Margin Account Transfer (MARGIN)
+      description: 'Weight(UID): 600'
       tags:
         - Margin
       parameters:
@@ -3224,7 +3470,7 @@ paths:
         - If "symbols" is not sent, all isolated assets will be returned.
         - If "symbols" is sent, only the isolated assets of the sent symbols will be returned.
         
-        Weight: 1
+        Weight(IP): 10
       tags:
         - Margin
       parameters:
@@ -3258,7 +3504,7 @@ paths:
       description: |-
         Disable isolated margin account for a specific symbol. Each trading pair can only be deactivated once every 24 hours .
         
-        Weight: 1
+        Weight(UID): 300
       tags:
         - Margin
       parameters:
@@ -3281,6 +3527,9 @@ paths:
                   symbol: 
                     type: string
                     example: "BTCUSDT"
+                required:
+                    - success
+                    - symbol
         '400':
           description: Bad Request
           content:
@@ -3298,7 +3547,7 @@ paths:
       description: |-
         Enable isolated margin account for a specific symbol.
         
-        Weight: 1
+        Weight(UID): 300
       tags:
         - Margin
       parameters:
@@ -3321,6 +3570,9 @@ paths:
                   symbol: 
                     type: string
                     example: "BTCUSDT"
+                required:
+                    - success
+                    - symbol
         '400':
           description: Bad Request
           content:
@@ -3339,7 +3591,7 @@ paths:
       description: |-
         Query enabled isolated margin account limit.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Margin
       parameters:
@@ -3358,10 +3610,15 @@ paths:
                 properties:
                   enabledAccount: 
                     type: integer
+                    format: int64
                     example: 5
                   maxAccount: 
                     type: integer
+                    format: int64
                     example: 20
+                required:
+                    - enabledAccount
+                    - maxAccount
         '400':
           description: Bad Request
           content:
@@ -3377,7 +3634,7 @@ paths:
   /sapi/v1/margin/isolated/pair:
     get:
       summary: Query Isolated Margin Symbol (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Margin
       parameters:
@@ -3410,6 +3667,13 @@ paths:
                     type: boolean
                   isSellAllowed:
                     type: boolean
+                required:
+                    - symbol
+                    - base
+                    - quote
+                    - isMarginTrade
+                    - isBuyAllowed
+                    - isSellAllowed
         '400':
           description: Bad Request
           content:
@@ -3425,7 +3689,7 @@ paths:
   /sapi/v1/margin/isolated/allPairs:
     get:
       summary: Get All Isolated Margin Symbol(USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Margin
       parameters:
@@ -3459,6 +3723,13 @@ paths:
                       type: boolean
                     isSellAllowed:
                       type: boolean
+                  required:
+                      - symbol
+                      - base
+                      - quote
+                      - isMarginTrade
+                      - isBuyAllowed
+                      - isSellAllowed
         '400':
           description: Bad Request
           content:
@@ -3477,7 +3748,7 @@ paths:
       description: |-
         - "spotBNBBurn" and "interestBNBBurn" should be sent at least one.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Margin
       parameters:
@@ -3521,7 +3792,7 @@ paths:
                 $ref: '#/components/schemas/error'
     get:
       summary: Get All Isolated Margin Symbol(USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Margin
       parameters:
@@ -3552,7 +3823,7 @@ paths:
   /sapi/v1/margin/interestRateHistory:
     get:
       summary: Margin Interest Rate History (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Margin
       parameters:
@@ -3562,6 +3833,7 @@ paths:
           description: Defaults to user's vip level
           schema:
             type: integer
+            format: int32
           example: 1
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
@@ -3589,10 +3861,17 @@ paths:
                       example: '0.00025000'
                     timestamp:
                       type: integer
+                      format: int64
                       example: 1611544731000
                     vipLevel:
                       type: integer
+                      format: int32
                       example: 1
+                  required:
+                      - asset
+                      - dailyInterestRate
+                      - timestamp
+                      - vipLevel
         '400':
           description: Bad Request
           content:
@@ -3611,7 +3890,7 @@ paths:
       description: |-
         Fetch system status.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       responses:
@@ -3624,19 +3903,23 @@ paths:
                 properties:
                   status:
                     type: integer
+                    format: int32
                     example: 0
                     description: "0: normal, 1：system maintenance"
                   msg:
                     type: string
                     example: "normal"
-                    description: normal|system maintenance
+                    description: '"normal", "system_maintenance"'
+                required:
+                    - status
+                    - msg
   /sapi/v1/capital/config/getall:
     get:
       summary: All Coins' Information (USER_DATA)
       description: |-
         Get information of coins (available for deposit and withdraw) for user.
 
-        Weight: 1
+        Weight(IP): 10
       tags:
         - Wallet
       parameters:
@@ -3707,6 +3990,7 @@ paths:
                             example: "^[0-9A-Za-z\\-_]{1,120}$"
                           minConfirm:
                             type: integer
+                            format: int64
                             example: 1
                             description: 'min number for balance confirmation.'
                           name:
@@ -3720,6 +4004,7 @@ paths:
                             example: "Both a MEMO and an Address are required to successfully deposit your BEP2-BTCB tokens to Binance."
                           unLockConfirm:
                             type: integer
+                            format: int64
                             example: 0
                             description: 'confirmation number for balance unlock.'
                           withdrawDesc:
@@ -3743,6 +4028,25 @@ paths:
                             example: "0.00000440"
                           sameAddress:
                             type: boolean
+                        required:
+                            - addressRegex
+                            - coin
+                            - depositDesc
+                            - depositEnable
+                            - isDefault
+                            - memoRegex
+                            - minConfirm
+                            - name
+                            - resetAddressStatus
+                            - specialTips
+                            - unLockConfirm
+                            - withdrawDesc
+                            - withdrawEnable
+                            - withdrawFee
+                            - withdrawIntegerMultiple
+                            - withdrawMax
+                            - withdrawMin
+                            - sameAddress
                     storage:
                       type: string
                       example: "0.00000000"
@@ -3753,6 +4057,21 @@ paths:
                     withdrawing:
                       type: string
                       example: "0.00000000"
+                  required:
+                      - coin
+                      - depositAllEnable
+                      - free
+                      - freeze
+                      - ipoable
+                      - ipoing
+                      - isLegalMoney
+                      - locked
+                      - name
+                      - networkList
+                      - storage
+                      - trading
+                      - withdrawAllEnable
+                      - withdrawing
         '400':
           description: Bad Request
           content:
@@ -3768,7 +4087,7 @@ paths:
   /sapi/v1/accountSnapshot:
     get:
       summary: Daily Account Snapshot (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 2400'
       tags:
         - Wallet
       parameters:
@@ -3784,6 +4103,7 @@ paths:
           in: query
           schema:
             type: integer
+            format: int32
             default: 5
             minimum: 5
             maximum: 30
@@ -3821,6 +4141,7 @@ paths:
         - This request will disable fastwithdraw switch under your account.
         - You need to enable "trade" option for the api key which requests this endpoint.
 
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -3855,6 +4176,7 @@ paths:
         - This request will enable fastwithdraw switch under your account. You need to enable "trade" option for the api key which requests this endpoint.
         - When Fast Withdraw Switch is on, transferring funds to a Binance account will be done instantly. There is no on-chain transaction, no transaction ID and no withdrawal fee.
 
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -3891,7 +4213,7 @@ paths:
         - If `network` not send, return with default network of the coin.
         - You can get `network` and `isDefault` in `networkList` of a coin in the response of `Get /sapi/v1/capital/config/getall (HMAC SHA256)`.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -3946,6 +4268,8 @@ paths:
                   id:
                     type: string
                     example: "7213fea8e94b4a5593d507237e5a555b"
+                required:
+                    - id
         '400':
           description: Bad Request
           content:
@@ -3967,7 +4291,7 @@ paths:
         - Please notice the default `startTime` and `endTime` to make sure that time interval is within 0-90 days.
         - If both `startTime` and `endTime` are sent, time between `startTime` and `endTime` must be less than 90 days.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -3980,6 +4304,7 @@ paths:
             1 -> success
           schema:
             type: integer
+            format: int32
             enum: [0, 6, 1]
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
@@ -4011,6 +4336,7 @@ paths:
                       example: "ETH"
                     status: 
                       type: integer
+                      format: int32
                       example: 1
                     address: 
                       type: string
@@ -4023,9 +4349,11 @@ paths:
                       example: "0xaad4654a3234aa6118af9b4b335f5ae81c360b2394721c019b5d1e75328b09f3"
                     insertTime: 
                       type: integer
+                      format: int64
                       example: 1599621997000
                     transferType: 
                       type: integer
+                      format: int32
                       example: 0
                     unlockConfirm: 
                       type: string
@@ -4034,6 +4362,18 @@ paths:
                     confirmTimes: 
                       type: string
                       example: "12/12"
+                  required:
+                      - amount
+                      - coin
+                      - network
+                      - status
+                      - address
+                      - addressTag
+                      - txId
+                      - insertTime
+                      - transferType
+                      - unlockConfirm
+                      - confirmTimes
         '400':
           description: Bad Request
           content:
@@ -4056,7 +4396,7 @@ paths:
         - Please notice the default `startTime` and `endTime` to make sure that time interval is within 0-90 days.
         - If both `startTime` and `endTime` are sent, time between `startTime` and `endTime` must be less than 90 days
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -4077,6 +4417,7 @@ paths:
             6:Completed
           schema:
             type: integer
+            format: int32
             enum: [0,1,2,3,4,5,6]
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
@@ -4121,20 +4462,36 @@ paths:
                       example: "ETH"
                     transferType: 
                       type: integer
+                      format: int32
                       example: 0
                       description: 1 for internal transfer, 0 for external transfer
                     status: 
                       type: integer
+                      format: int32
                       example: 6
                     transactionFee: 
                       type: string
                       example: "0.004"
                     confirmNo:
                       type: integer
+                      format: int32
                       example: 3
                     txId: 
                       type: string
                       example: "0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268"
+                  required:
+                      - address
+                      - amount
+                      - applyTime
+                      - coin
+                      - id
+                      - withdrawOrderId
+                      - network
+                      - transferType
+                      - status
+                      - transactionFee
+                      - confirmNo
+                      - txId
         '400':
           description: Bad Request
           content:
@@ -4156,7 +4513,7 @@ paths:
         - If network is not send, return with default network of the coin.
         - You can get network and isDefault in networkList in the response of Get /sapi/v1/capital/config/getall (HMAC SHA256).
 
-        Weight: 1
+        Weight(IP): 10
       tags:
         - Wallet
       parameters:
@@ -4191,6 +4548,11 @@ paths:
                   url:
                     type: string
                     example: "https://btc.com/1HPn8Rx2y6nNSfagQBKy27GB99Vbzg89wv"
+                required:
+                    - address
+                    - coin
+                    - tag
+                    - url
         '400':
           description: Bad Request
           content:
@@ -4209,7 +4571,7 @@ paths:
       description: |-
         Fetch account status detail.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -4229,6 +4591,8 @@ paths:
                   data:
                     type: string
                     example: "Normal"
+                required:
+                    - data
         '400':
           description: Bad Request
           content:
@@ -4247,7 +4611,7 @@ paths:
       description: |-
         Fetch account API trading status with details.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -4273,6 +4637,7 @@ paths:
                         description: API trading function is locked or not
                       plannedRecoverTime:
                         type: integer
+                        format: int64
                         example: 0
                         description: If API trading function is locked, this is the planned recover time
                       triggerCondition:
@@ -4280,16 +4645,23 @@ paths:
                         properties:
                           GCR:
                             type: integer
+                            format: int64
                             example: 150
                             description: Number of GTC orders
                           IFER:
                             type: integer
+                            format: int64
                             example: 150
                             description: Number of FOK/IOC orders
                           UFR:
                             type: integer
+                            format: int64
                             example: 300
                             description: Number of orders
+                        required:
+                            - GCR
+                            - IFER
+                            - UFR
                       indicators:
                         description: The indicators updated every 30 seconds
                         type: object
@@ -4305,19 +4677,38 @@ paths:
                                   description: Unfilled Ratio (UFR)
                                 c:
                                   type: integer
+                                  format: int64
                                   example: 20
                                   description: Count of all orders
                                 v:
                                   type: number
+                                  format: float
                                   example: 0.05
                                   description: Current UFR value
                                 t:
                                   type: number
+                                  format: float
                                   example: 0.99
                                   description: Trigger UFR value
+                              required:
+                                  - i
+                                  - c
+                                  - v
+                                  - t
+                        required:
+                            - BTCUSDT
                       updateTime:
                         type: integer
+                        format: int64
                         example: 1547630471725
+                    required:
+                        - isLocked
+                        - plannedRecoverTime
+                        - triggerCondition
+                        - indicators
+                        - updateTime
+                required:
+                    - data
         '400':
           description: Bad Request
           content:
@@ -4333,7 +4724,7 @@ paths:
   /sapi/v1/asset/dribblet:
     get:
       summary: DustLog(USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Wallet
       parameters:
@@ -4355,6 +4746,7 @@ paths:
                   total:
                     description: Total counts of exchange
                     type: integer
+                    format: int64
                     example: 8
                   userAssetDribblets:
                     type: array
@@ -4363,6 +4755,7 @@ paths:
                       properties:
                         operateTime:
                           type: integer
+                          format: int64
                           example: 1615985535000
                         totalTransferedAmount:
                           type: string
@@ -4374,6 +4767,7 @@ paths:
                           description: Total service charge amount for this exchange.
                         transId:
                           type: integer
+                          format: int64
                           example: 45178372831
                         userAssetDribbletDetails:
                           type: array
@@ -4382,6 +4776,7 @@ paths:
                             properties:
                               transId:
                                 type: integer
+                                format: int64
                                 example: 4359321
                               serviceChargeAmount:
                                 type: string
@@ -4391,6 +4786,7 @@ paths:
                                 example: "0.0009"
                               operateTime:
                                 type: integer
+                                format: int64
                                 example: 1615985535000
                               transferedAmount:
                                 type: string
@@ -4398,6 +4794,22 @@ paths:
                               fromAsset:
                                 type: string
                                 example: "USDT"
+                            required:
+                                - transId
+                                - serviceChargeAmount
+                                - amount
+                                - operateTime
+                                - transferedAmount
+                                - fromAsset
+                      required:
+                          - operateTime
+                          - totalTransferedAmount
+                          - totalServiceChargeAmount
+                          - transId
+                          - userAssetDribbletDetails
+                required:
+                    - total
+                    - userAssetDribblets
         '400':
           description: Bad Request
           content:
@@ -4416,7 +4828,7 @@ paths:
       description: |-
         Convert dust assets to BNB.
 
-        Weight: 1
+        Weight(UID): 10
       tags:
         - Wallet
       parameters:
@@ -4459,16 +4871,29 @@ paths:
                           example: "ETH"
                         operateTime:
                           type: integer
+                          format: int64
                           example: 1563368549307
                         serviceChargeAmount:
                           type: string
                           example: "0.00500000"
                         tranId:
                           type: integer
+                          format: int64
                           example: 2970932918
                         transferedAmount:
                           type: string
                           example: "0.25000000"
+                      required:
+                          - amount
+                          - fromAsset
+                          - operateTime
+                          - serviceChargeAmount
+                          - tranId
+                          - transferedAmount
+                required:
+                    - totalServiceCharge
+                    - totalTransfered
+                    - transferResult
         '400':
           description: Bad Request
           content:
@@ -4487,7 +4912,7 @@ paths:
       description: |-
         Query asset Dividend Record
 
-        Weight: 1
+        Weight(IP): 10
       tags:
         - Wallet
       parameters:
@@ -4519,6 +4944,10 @@ paths:
                     items:
                       type: object
                       properties:
+                        id:
+                          type: integer
+                          format: int64
+                          example: 242006910
                         amount:
                           type: string
                           example: "10.00000000"
@@ -4527,16 +4956,29 @@ paths:
                           example: "BHFT"
                         divTime:
                           type: integer
+                          format: int64
                           example: 1563189166000
                         enInfo:
                           type: string
                           example: "BHFT distribution"
                         tranId:
                           type: integer
+                          format: int64
                           example: 2968885920
+                      required:
+                          - id
+                          - amount
+                          - asset
+                          - divTime
+                          - enInfo
+                          - tranId
                   total:
                     type: integer
+                    format: int32
                     example: 1
+                required:
+                    - rows
+                    - total
         '400':
           description: Bad Request
           content:
@@ -4557,7 +4999,7 @@ paths:
 
         - Please get network and other deposit or withdraw details from `GET /sapi/v1/capital/config/getall`.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -4587,6 +5029,7 @@ paths:
                         description: deposit status (false if ALL of networks' are false)
                       withdrawFee:
                         type: integer
+                        format: int64
                         example: 35
                       withdrawStatus:
                         type: boolean
@@ -4594,6 +5037,14 @@ paths:
                       depositTip:
                         type: string
                         example: "Delisted, Deposit Suspended"
+                    required:
+                        - minWithdrawAmount
+                        - depositStatus
+                        - withdrawFee
+                        - withdrawStatus
+                        - depositTip
+                required:
+                    - CTR
         '400':
           description: Bad Request
           content:
@@ -4612,7 +5063,7 @@ paths:
       description: |-
         Fetch trade fee
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -4641,6 +5092,10 @@ paths:
                     takerCommission:
                       type: string
                       example: "0.001"
+                  required:
+                      - symbol
+                      - makerCommission
+                      - takerCommission
         '400':
           description: Bad Request
           content:
@@ -4660,7 +5115,7 @@ paths:
         - `fromSymbol` must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN
         - `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -4686,6 +5141,7 @@ paths:
                 properties:
                   total:
                     type: integer
+                    format: int32
                     example: 1
                   rows:
                     type: array
@@ -4706,10 +5162,22 @@ paths:
                           example: "CONFIRMED"
                         tranId:
                           type: integer
+                          format: int64
                           example: 11415955596
                         timestamp:
                           type: integer
+                          format: int64
                           example: 1544433328000
+                      required:
+                          - asset
+                          - amount
+                          - type
+                          - status
+                          - tranId
+                          - timestamp
+                required:
+                    - total
+                    - rows
         '400':
           description: Bad Request
           content:
@@ -4731,17 +5199,11 @@ paths:
         - `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN
 
         ENUM of transfer types:
-        - MAIN_C2C Spot account transfer to C2C account
         - MAIN_UMFUTURE Spot account transfer to USDⓈ-M Futures account
         - MAIN_CMFUTURE Spot account transfer to COIN-M Futures account
         - MAIN_MARGIN Spot account transfer to Margin（cross）account
         - MAIN_MINING Spot account transfer to Mining account
-        - C2C_MAIN C2C account transfer to Spot account
-        - C2C_UMFUTURE C2C account transfer to USDⓈ-M Futures account
-        - C2C_MINING C2C account transfer to Mining account
-        - C2C_MARGIN C2C account transfer to Margin(cross) account
         - UMFUTURE_MAIN USDⓈ-M Futures account transfer to Spot account
-        - UMFUTURE_C2C USDⓈ-M Futures account transfer to C2C account
         - UMFUTURE_MARGIN USDⓈ-M Futures account transfer to Margin（cross）account
         - CMFUTURE_MAIN COIN-M Futures account transfer to Spot account
         - CMFUTURE_MARGIN COIN-M Futures account transfer to Margin(cross) account
@@ -4749,18 +5211,22 @@ paths:
         - MARGIN_UMFUTURE Margin（cross）account transfer to USDⓈ-M Futures
         - MARGIN_CMFUTURE Margin（cross）account transfer to COIN-M Futures
         - MARGIN_MINING Margin（cross）account transfer to Mining account
-        - MARGIN_C2C Margin（cross）account transfer to C2C account
         - MINING_MAIN Mining account transfer to Spot account
         - MINING_UMFUTURE Mining account transfer to USDⓈ-M Futures account
-        - MINING_C2C Mining account transfer to C2C account
         - MINING_MARGIN Mining account transfer to Margin(cross) account
-        - MAIN_PAY Spot account transfer to Pay account
-        - PAY_MAIN Pay account transfer to Spot account
         - ISOLATEDMARGIN_MARGIN Isolated margin account transfer to Margin(cross) account
         - MARGIN_ISOLATEDMARGIN Margin(cross) account transfer to Isolated margin account
         - ISOLATEDMARGIN_ISOLATEDMARGIN Isolated margin account transfer to Isolated margin account
+        - MAIN_FUNDING Spot account transfer to Funding account
+        - FUNDING_MAIN Funding account transfer to Spot account
+        - FUNDING_UMFUTURE Funding account transfer to UMFUTURE account
+        - UMFUTURE_FUNDING UMFUTURE account transfer to Funding account
+        - MARGIN_FUNDING MARGIN account transfer to Funding account
+        - FUNDING_MARGIN Funding account transfer to Margin account
+        - FUNDING_CMFUTURE Funding account transfer to CMFUTURE account
+        - CMFUTURE_FUNDING CMFUTURE account transfer to Funding account
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -4784,7 +5250,10 @@ paths:
                 properties:
                   tranId:
                     type: integer
+                    format: int64
                     example: 13526853623
+                required:
+                    - tranId
         '400':
           description: Bad Request
           content:
@@ -4803,7 +5272,7 @@ paths:
       description: |-
         - Currently supports querying the following business assets：Binance Pay, Binance Card, Binance Gift Card, Stock Token
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Wallet
       parameters:
@@ -4846,6 +5315,13 @@ paths:
                       btcValuation:
                         type: string
                         example: "0.00000091"
+                    required:
+                        - asset
+                        - free
+                        - locked
+                        - freeze
+                        - withdrawing
+                        - btcValuation
         '400':
           description: Bad Request
           content:
@@ -4861,7 +5337,7 @@ paths:
   /sapi/v1/account/apiRestrictions:
     get:
       summary: Get API Key Permission (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Wallet
       parameters:
@@ -4883,6 +5359,7 @@ paths:
                     example: false
                   createTime:
                     type: integer
+                    format: int64
                     example: 1623840271000
                   enableWithdrawals:
                     type: boolean
@@ -4913,8 +5390,21 @@ paths:
                     example: false
                   tradingAuthorityExpirationTime:
                     type: integer
+                    format: int64
                     example: 1628985600000
                     description: Expiration time for spot and margin trading permission
+                required:
+                    - ipRestrict
+                    - createTime
+                    - enableWithdrawals
+                    - enableInternalTransfer
+                    - permitsUniversalTransfer
+                    - enableVanillaOptions
+                    - enableReading
+                    - enableFutures
+                    - enableMargin
+                    - enableSpotAndMarginTrading
+                    - tradingAuthorityExpirationTime
         '400':
           description: Bad Request
           content:
@@ -4934,7 +5424,7 @@ paths:
         - This request will generate a virtual sub account under your master account.
         - You need to enable "trade" option for the api key which requests this endpoint.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -4960,6 +5450,8 @@ paths:
                   email: 
                     type: string
                     example: "addsdd_virtual@aasaixwqnoemail.com"
+                required:
+                    - email
         '400':
           description: Bad Request
           content:
@@ -4975,7 +5467,7 @@ paths:
   /sapi/v1/sub-account/list:
     get:
       summary: Query Sub-account List (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -4991,6 +5483,7 @@ paths:
           description: Default 1; max 200
           schema:
             type: integer
+            format: int32
             example: 1
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -5018,7 +5511,14 @@ paths:
                           example: false
                         createTime: 
                           type: integer
+                          format: int64
                           example: 1544433328000
+                      required:
+                          - email
+                          - isFreeze
+                          - createTime
+                required:
+                    - subAccounts
         '400':
           description: Bad Request
           content:
@@ -5038,7 +5538,7 @@ paths:
         - fromEmail and toEmail cannot be sent at the same time.
         - Return fromEmail equal master account email by default.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -5052,6 +5552,7 @@ paths:
           description: Default 1
           schema:
             type: integer
+            format: int32
             example: 1
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -5085,10 +5586,20 @@ paths:
                       example: SUCCESS
                     tranId: 
                       type: integer
+                      format: int64
                       example: 6489943656
                     time: 
                       type: integer
+                      format: int64
                       example: 1544433328000
+                  required:
+                      - from
+                      - to
+                      - asset
+                      - qty
+                      - status
+                      - tranId
+                      - time
         '400':
           description: Bad Request
           content:
@@ -5104,7 +5615,7 @@ paths:
   /sapi/v1/sub-account/futures/internalTransfer:
     get:
       summary: Sub-account Futures Asset Transfer History (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -5115,6 +5626,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int32
             example: 2
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
@@ -5124,6 +5636,7 @@ paths:
           description: 'Default value: 50, Max value: 500'
           schema:
             type: integer
+            format: int32
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
         - $ref: '#/components/parameters/signature'
@@ -5141,6 +5654,7 @@ paths:
                     type: boolean
                   futuresType: 
                     type: integer
+                    format: int32
                     example: 2
                   transfers: 
                     type: array
@@ -5161,10 +5675,23 @@ paths:
                           example: "1"
                         tranId: 
                           type: integer
+                          format: int64
                           example: 11897001102
                         time: 
                           type: integer
+                          format: int64
                           example: 1544433328000
+                      required:
+                          - from
+                          - to
+                          - asset
+                          - qty
+                          - tranId
+                          - time
+                required:
+                    - success
+                    - futuresType
+                    - transfers
         '400':
           description: Bad Request
           content:
@@ -5182,7 +5709,7 @@ paths:
       description: |-
         - Master account can transfer max 2000 times a minute
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -5194,6 +5721,7 @@ paths:
           description: '1:USDT-margined Futures,2: Coin-margined Futures'
           schema:
             type: integer
+            format: int32
             example: 2
         - $ref: '#/components/parameters/asset'
         - $ref: '#/components/parameters/amount'
@@ -5215,6 +5743,9 @@ paths:
                   txnId: 
                     type: string
                     example: "2934662589"
+                required:
+                    - success
+                    - txnId
         '400':
           description: Bad Request
           content:
@@ -5233,7 +5764,7 @@ paths:
       description: |-
         Fetch sub-account assets
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -5261,10 +5792,18 @@ paths:
                           example: "ADA"
                         free: 
                           type: integer
+                          format: int64
                           example: 10000
                         locked: 
                           type: integer
+                          format: int64
                           example: 0
+                      required:
+                          - asset
+                          - free
+                          - locked
+                required:
+                    - balances
         '400':
           description: Bad Request
           content:
@@ -5283,7 +5822,7 @@ paths:
       description: |-
         Get BTC valued asset summary of subaccounts.
         
-        Weight: 5
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -5294,6 +5833,7 @@ paths:
           description: Default:10 Max:20
           schema:
             type: integer
+            format: int32
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
         - $ref: '#/components/parameters/signature'
@@ -5309,6 +5849,7 @@ paths:
                 properties: 
                   totalCount: 
                     type: integer
+                    format: int64
                     example: 1
                   masterAccountTotalAsset: 
                     type: string
@@ -5324,6 +5865,13 @@ paths:
                         totalAsset: 
                           type: string
                           example: "9999.00000000"
+                      required:
+                          - email
+                          - totalAsset
+                required:
+                    - totalCount
+                    - masterAccountTotalAsset
+                    - spotSubUserAssetBtcVoList
         '400':
           description: Bad Request
           content:
@@ -5342,7 +5890,7 @@ paths:
       description: |-
         Fetch sub-account deposit address
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -5377,6 +5925,11 @@ paths:
                   url: 
                     type: string
                     example: "https://tronscan.org/#/address/TDunhSa7jkTNuKrusUTU1MUHtqXoBPKETV"
+                required:
+                    - address
+                    - coin
+                    - tag
+                    - url
         '400':
           description: Bad Request
           content:
@@ -5395,7 +5948,7 @@ paths:
       description: |-
         Fetch sub-account deposit history
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -5406,12 +5959,14 @@ paths:
           description: '0(0:pending,6: credited but cannot withdraw, 1:success)'
           schema:
             type: integer
+            format: int32
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
         - name: limit
           in: query
           schema:
             type: integer
+            format: int64
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -5439,6 +5994,7 @@ paths:
                       example: "ETH"
                     status: 
                       type: integer
+                      format: int32
                       example: 1
                     address: 
                       type: string
@@ -5451,13 +6007,26 @@ paths:
                       example: "0xaad4654a3234aa6118af9b4b335f5ae81c360b2394721c019b5d1e75328b09f3"
                     insertTime: 
                       type: integer
+                      format: int64
                       example: 1599621997000
                     transferType: 
                       type: integer
+                      format: int32
                       example: 0
                     confirmTimes: 
                       type: string
                       example: "12/12"
+                  required:
+                      - amount
+                      - coin
+                      - network
+                      - status
+                      - address
+                      - addressTag
+                      - txId
+                      - insertTime
+                      - transferType
+                      - confirmTimes
         '400':
           description: Bad Request
           content:
@@ -5475,7 +6044,8 @@ paths:
       summary: Sub-account's Status on Margin/Futures (For Master Account)
       description: |-
         - If no `email` sent, all sub-accounts' information will be returned.
-        Weight: 1
+
+        Weight(IP): 10
       tags:
         - Sub-Account
       parameters:
@@ -5504,6 +6074,7 @@ paths:
                       type: boolean
                     insertTime: 
                       type: integer
+                      format: int64
                       example: 1570791523523
                       description: sub account create time
                     isMarginEnabled: 
@@ -5512,8 +6083,17 @@ paths:
                       type: boolean
                     mobile: 
                       type: integer
+                      format: int64
                       example: 1570791523523
                       description: user mobile number
+                  required:
+                      - email
+                      - isSubUserEnabled
+                      - isUserActive
+                      - insertTime
+                      - isMarginEnabled
+                      - isFutureEnabled
+                      - mobile
         '400':
           description: Bad Request
           content:
@@ -5529,7 +6109,7 @@ paths:
   /sapi/v1/sub-account/margin/enable:
     post:
       summary: Enable Margin for Sub-account (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -5552,6 +6132,9 @@ paths:
                     example: "123@test.com"
                   isMarginEnabled: 
                     type: boolean
+                required:
+                    - email
+                    - isMarginEnabled
         '400':
           description: Bad Request
           content:
@@ -5567,7 +6150,7 @@ paths:
   /sapi/v1/sub-account/margin/account:
     get:
       summary: Detail on Sub-account's Margin Account (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Sub-Account
       parameters:
@@ -5615,6 +6198,10 @@ paths:
                         type: string
                         example: "2.00000000"
                         description: Initial margin ratio
+                    required:
+                        - forceLiquidationBar
+                        - marginCallBar
+                        - normalBar
                   marginUserAssetVoList: 
                     type: array
                     items: 
@@ -5638,6 +6225,21 @@ paths:
                         netAsset: 
                           type: string
                           example: "0.00499500"
+                      required:
+                          - asset
+                          - borrowed
+                          - free
+                          - interest
+                          - locked
+                          - netAsset
+                required:
+                    - email
+                    - marginLevel
+                    - totalAssetOfBtc
+                    - totalLiabilityOfBtc
+                    - totalNetAssetOfBtc
+                    - marginTradeCoeffVo
+                    - marginUserAssetVoList
         '400':
           description: Bad Request
           content:
@@ -5653,7 +6255,7 @@ paths:
   /sapi/v1/sub-account/margin/accountSummary:
     get:
       summary: Summary of Sub-account's Margin Account (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Sub-Account
       parameters:
@@ -5696,6 +6298,16 @@ paths:
                         totalNetAssetOfBtc: 
                           type: string
                           example: "1.00000000"
+                      required:
+                          - email
+                          - totalAssetOfBtc
+                          - totalLiabilityOfBtc
+                          - totalNetAssetOfBtc
+                required:
+                    - totalAssetOfBtc
+                    - totalLiabilityOfBtc
+                    - totalNetAssetOfBtc
+                    - subAccountList
         '400':
           description: Bad Request
           content:
@@ -5711,7 +6323,7 @@ paths:
   /sapi/v1/sub-account/futures/enable:
     post:
       summary: Enable Futures for Sub-account (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -5734,6 +6346,9 @@ paths:
                     example: "123@test.com"
                   isFuturesEnabled: 
                     type: boolean
+                required:
+                    - email
+                    - isFuturesEnabled
         '400':
           description: Bad Request
           content:
@@ -5749,7 +6364,7 @@ paths:
   /sapi/v1/sub-account/futures/account:
     get:
       summary: Detail on Sub-account's Futures Account (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Sub-Account
       parameters:
@@ -5805,6 +6420,16 @@ paths:
                         walletBalance: 
                           type: string
                           example: "0.88308000"
+                      required:
+                          - asset
+                          - initialMargin
+                          - maintenanceMargin
+                          - marginBalance
+                          - maxWithdrawAmount
+                          - openOrderInitialMargin
+                          - positionInitialMargin
+                          - unrealizedProfit
+                          - walletBalance
                   canDeposit: 
                     type: boolean
                   canTrade: 
@@ -5813,6 +6438,7 @@ paths:
                     type: boolean
                   feeTier: 
                     type: integer
+                    format: int64
                     example: 2
                   maxWithdrawAmount: 
                     type: string
@@ -5840,7 +6466,25 @@ paths:
                     example: "0.88308000"
                   updateTime: 
                     type: integer
+                    format: int64
                     example: 1576756674610
+                required:
+                    - email
+                    - asset
+                    - assets
+                    - canDeposit
+                    - canTrade
+                    - canWithdraw
+                    - feeTier
+                    - maxWithdrawAmount
+                    - totalInitialMargin
+                    - totalMaintenanceMargin
+                    - totalMarginBalance
+                    - totalOpenOrderInitialMargin
+                    - totalPositionInitialMargin
+                    - totalUnrealizedProfit
+                    - totalWalletBalance
+                    - updateTime
         '400':
           description: Bad Request
           content:
@@ -5856,7 +6500,7 @@ paths:
   /sapi/v1/sub-account/futures/accountSummary:
     get:
       summary: Summary of Sub-account's Futures Account (For Master Account)
-      description: 'Weight: 20'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -5929,6 +6573,26 @@ paths:
                         asset: 
                           type: string
                           example: "USD"
+                      required:
+                          - email
+                          - totalInitialMargin
+                          - totalMaintenanceMargin
+                          - totalMarginBalance
+                          - totalOpenOrderInitialMargin
+                          - totalPositionInitialMargin
+                          - totalUnrealizedProfit
+                          - totalWalletBalance
+                          - asset
+                required:
+                    - totalInitialMargin
+                    - totalMaintenanceMargin
+                    - totalMarginBalance
+                    - totalOpenOrderInitialMargin
+                    - totalPositionInitialMargin
+                    - totalUnrealizedProfit
+                    - totalWalletBalance
+                    - asset
+                    - subAccountList
         '400':
           description: Bad Request
           content:
@@ -5944,7 +6608,7 @@ paths:
   /sapi/v1/sub-account/futures/positionRisk:
     get:
       summary: Futures Position-Risk of Sub-account (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 10'
       tags:
         - Sub-Account
       parameters:
@@ -5990,6 +6654,15 @@ paths:
                     unrealizedProfit: 
                       type: string
                       example: "-0.01612295"
+                  required:
+                      - entryPrice
+                      - leverage
+                      - maxNotional
+                      - liquidationPrice
+                      - markPrice
+                      - positionAmount
+                      - symbol
+                      - unrealizedProfit
         '400':
           description: Bad Request
           content:
@@ -6005,7 +6678,7 @@ paths:
   /sapi/v1/sub-account/futures/transfer:
     post:
       summary: Transfer for Sub-account (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6025,6 +6698,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int32
             enum: [1,2,3,4]
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -6042,6 +6716,8 @@ paths:
                   txnId: 
                     type: string
                     example: "2966662589"
+                required:
+                    - txnId
         '400':
           description: Bad Request
           content:
@@ -6057,7 +6733,7 @@ paths:
   /sapi/v1/sub-account/margin/transfer:
     post:
       summary: Margin Transfer for Sub-account (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6073,6 +6749,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int32
             enum: [1,2]
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -6090,6 +6767,8 @@ paths:
                   txnId: 
                     type: string
                     example: "2966662589"
+                required:
+                    - txnId
         '400':
           description: Bad Request
           content:
@@ -6105,7 +6784,7 @@ paths:
   /sapi/v1/sub-account/transfer/subToSub:
     post:
       summary: Transfer to Sub-account of Same Master (For Sub-account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6128,6 +6807,8 @@ paths:
                   txnId: 
                     type: string
                     example: "2966662589"
+                required:
+                    - txnId
         '400':
           description: Bad Request
           content:
@@ -6143,7 +6824,7 @@ paths:
   /sapi/v1/sub-account/transfer/subToMaster:
     post:
       summary: Transfer to Master (For Sub-account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6165,6 +6846,8 @@ paths:
                   txnId: 
                     type: string
                     example: "2966662589"
+                required:
+                    - txnId
         '400':
           description: Bad Request
           content:
@@ -6184,7 +6867,7 @@ paths:
         - If `type` is not sent, the records of type 2: transfer out will be returned by default.
         - If `startTime` and `endTime` are not sent, the recent 30-day data will be returned.
 
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -6197,6 +6880,7 @@ paths:
             2:  transfer out
           schema:
             type: integer
+            format: int32
             enum: [1,2]
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
@@ -6224,6 +6908,7 @@ paths:
                       example: "master@test.com"
                     type: 
                       type: integer
+                      format: int32
                       example: 1
                       description: 1 for transfer in, 2 for transfer out
                     asset: 
@@ -6243,10 +6928,23 @@ paths:
                       example: "SUCCESS"
                     tranId: 
                       type: integer
+                      format: int64
                       example: 11798835829
                     time: 
                       type: integer
+                      format: int64
                       example: 1544433325000
+                  required:
+                      - counterParty
+                      - email
+                      - type
+                      - asset
+                      - qty
+                      - fromAccountType
+                      - toAccountType
+                      - status
+                      - tranId
+                      - time
         '400':
           description: Bad Request
           content:
@@ -6267,7 +6965,7 @@ paths:
         - Return fromEmail equal master account email by default.
         - Only get the latest history of past 30 days.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -6298,6 +6996,7 @@ paths:
                   properties: 
                     tranId: 
                       type: integer
+                      format: int64
                       example: 11945860693
                     fromEmail: 
                       type: string
@@ -6322,7 +7021,18 @@ paths:
                       example: "SUCCESS"
                     createTimeStamp: 
                       type: integer
+                      format: int64
                       example: 1544433325000
+                  required:
+                      - tranId
+                      - fromEmail
+                      - toEmail
+                      - asset
+                      - amount
+                      - fromAccountType
+                      - toAccountType
+                      - status
+                      - createTimeStamp
         '400':
           description: Bad Request
           content:
@@ -6343,7 +7053,7 @@ paths:
         - Transfer to master account by default if toEmail is not sent.
         - Transfer between futures accounts is not supported.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Sub-Account
       parameters:
@@ -6378,7 +7088,10 @@ paths:
                 properties: 
                   tranId: 
                     type: integer
+                    format: int64
                     example: 11945860693
+                required:
+                    - tranId
         '400':
           description: Bad Request
           content:
@@ -6394,7 +7107,7 @@ paths:
   /sapi/v2/sub-account/futures/account:
     get:
       summary: Detail on Sub-account's Futures Account V2 (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6408,6 +7121,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int32
             enum: [1,2]
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -6423,7 +7137,6 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/subAccountUSDTFuturesDetails'
                   - $ref: '#/components/schemas/subAccountCOINFuturesDetails'
-
         '400':
           description: Bad Request
           content:
@@ -6439,7 +7152,7 @@ paths:
   /sapi/v2/sub-account/futures/accountSummary:
     get:
       summary: Summary of Sub-account's Futures Account V2 (For Master Account)
-      description: 'Weight: 20'
+      description: 'Weight(IP): 10'
       tags:
         - Sub-Account
       parameters:
@@ -6452,6 +7165,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int32
             enum: [1,2]
         - $ref: '#/components/parameters/page'
         - name: limit
@@ -6488,7 +7202,7 @@ paths:
   /sapi/v2/sub-account/futures/positionRisk:
     get:
       summary: Futures Position-Risk of Sub-account V2 (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6502,6 +7216,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int32
             enum: [1,2]
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -6532,7 +7247,7 @@ paths:
   /sapi/v1/sub-account/blvt/enable:
     post:
       summary: Enable Leverage Token for Sub-account (For Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6561,6 +7276,9 @@ paths:
                     example: "123@test.com"
                   enableBlvt: 
                     type: boolean
+                required:
+                    - email
+                    - enableBlvt
         '400':
           description: Bad Request
           content:
@@ -6576,7 +7294,7 @@ paths:
   /sapi/v1/managed-subaccount/deposit:
     post:
       summary: Deposit assets into the managed sub-account（For Investor Master Account）
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6598,7 +7316,10 @@ paths:
                 properties:
                   tranId: 
                     type: integer
+                    format: int64
                     example: 66157362489
+                required:
+                    - tranId
         '400':
           description: Bad Request
           content:
@@ -6614,7 +7335,7 @@ paths:
   /sapi/v1/managed-subaccount/asset:
     get:
       summary: Managed sub-account asset details（For Investor Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6652,6 +7373,13 @@ paths:
                     btcValue: 
                       type: string
                       example: "0"
+                  required:
+                      - coin
+                      - name
+                      - totalBalance
+                      - availableBalance
+                      - inOrder
+                      - btcValue
         '400':
           description: Bad Request
           content:
@@ -6667,7 +7395,7 @@ paths:
   /sapi/v1/managed-subaccount/withdraw:
     post:
       summary: Withdrawl assets from the managed sub-account（For Investor Master Account)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Sub-Account
       parameters:
@@ -6679,6 +7407,7 @@ paths:
           description: Withdrawals is automatically occur on the transfer date(UTC0). If a date is not selected, the withdrawal occurs right now
           schema:
             type: integer
+            format: int64
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
         - $ref: '#/components/parameters/signature'
@@ -6694,7 +7423,10 @@ paths:
                 properties:
                   tranId: 
                     type: integer
+                    format: int64
                     example: 66157362489
+                required:
+                    - tranId
         '400':
           description: Bad Request
           content:
@@ -6730,6 +7462,8 @@ paths:
                   listenKey:
                     type: string
                     example: "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1"
+                required:
+                    - listenKey
     put:
       summary: Ping/Keep-alive a ListenKey (USER_STREAM)
       description: |-
@@ -6803,6 +7537,8 @@ paths:
                   listenKey:
                     type: string
                     example: "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1"
+                required:
+                    - listenKey
     put:
       summary: Ping/Keep-alive a ListenKey (USER_STREAM)
       description: |-
@@ -6876,6 +7612,8 @@ paths:
                   listenKey:
                     type: string
                     example: "T3ee22BIYuWqmvne0HNq2A2WsFlEtLhvWCtItw6ffhhdmjifQ2tRbuKkTHhr"
+                required:
+                    - listenKey
     put:
       summary: Ping/Keep-alive a Listen Key (USER_STREAM)
       description: |-
@@ -6932,7 +7670,7 @@ paths:
       description: |-
         - If beginTime and endTime are not sent, the recent 30-day data will be returned.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Fiat
       parameters:
@@ -6989,15 +7727,34 @@ paths:
                           description: "Processing, Failed, Successful, Finished, Refunding, Refunded, Refund Failed, Order Partial credit Stopped"
                         createTime:
                           type: integer
+                          format: int64
                           example: 1626144956000
                         updateTime:
                           type: integer
+                          format: int64
                           example: 1626400907000
+                      required:
+                          - orderNo
+                          - fiatCurrency
+                          - indicatedAmount
+                          - amount
+                          - totalFee
+                          - method
+                          - status
+                          - createTime
+                          - updateTime
                   total:
                     type: integer
+                    format: int32
                     example: 1
                   success:
                     type: boolean
+                required:
+                    - code
+                    - message
+                    - data
+                    - total
+                    - success
         '400':
           description: Bad Request
           content:
@@ -7016,7 +7773,7 @@ paths:
       description: |-
         - If beginTime and endTime are not sent, the recent 30-day data will be returned.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Fiat
       parameters:
@@ -7081,15 +7838,35 @@ paths:
                           description: Processing, Completed, Failed, Refunded
                         createTime:
                           type: integer
+                          format: int64
                           example: 1624529919000
                         updateTime:
                           type: integer
+                          format: int64
                           example: 1624529919000
+                      required:
+                          - orderNo
+                          - sourceAmount
+                          - fiatCurrency
+                          - obtainAmount
+                          - cryptoCurrency
+                          - totalFee
+                          - price
+                          - status
+                          - createTime
+                          - updateTime
                   total:
                     type: integer
+                    format: int32
                     example: 1
                   success:
                     type: boolean
+                required:
+                    - code
+                    - message
+                    - data
+                    - total
+                    - success
         '400':
           description: Bad Request
           content:
@@ -7105,7 +7882,7 @@ paths:
   /sapi/v1/lending/daily/product/list:
     get:
       summary: Get Flexible Product List (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7161,6 +7938,19 @@ paths:
                     upLimitPerUser:
                       type: string
                       example: "5.00000000"
+                  required:
+                      - asset
+                      - avgAnnualInterestRate
+                      - canPurchase
+                      - canRedeem
+                      - dailyInterestPerThousand
+                      - featured
+                      - minPurchaseAmount
+                      - productId
+                      - purchasedAmount
+                      - status
+                      - upLimit
+                      - upLimitPerUser
         '400':
           description: Bad Request
           content:
@@ -7176,7 +7966,7 @@ paths:
   /sapi/v1/lending/daily/userLeftQuota:
     get:
       summary: Get Left Daily Purchase Quota of Flexible Product (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7200,6 +7990,9 @@ paths:
                   leftQuota:
                     type: string
                     example: "50000.00000000"
+                required:
+                    - asset
+                    - leftQuota
         '400':
           description: Bad Request
           content:
@@ -7215,7 +8008,7 @@ paths:
   /sapi/v1/lending/daily/purchase:
     post:
       summary: Purchase Flexible Product (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7236,7 +8029,10 @@ paths:
                 properties:
                   purchaseId:
                     type: integer
+                    format: int64
                     example: 40607
+                required:
+                    - purchaseId
         '400':
           description: Bad Request
           content:
@@ -7252,7 +8048,7 @@ paths:
   /sapi/v1/lending/daily/userRedemptionQuota:
     get:
       summary: Get Left Daily Redemption Quota of Flexible Product (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7283,6 +8079,11 @@ paths:
                   minRedemptionAmount:
                     type: string
                     example: "0.10000000"
+                required:
+                    - asset
+                    - dailyQuota
+                    - leftQuota
+                    - minRedemptionAmount
         '400':
           description: Bad Request
           content:
@@ -7298,7 +8099,7 @@ paths:
   /sapi/v1/lending/daily/redeem:
     post:
       summary: Redeem Flexible Product (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7332,7 +8133,7 @@ paths:
   /sapi/v1/lending/daily/token/position:
     get:
       summary: Get Flexible Product Position (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7393,6 +8194,21 @@ paths:
                     totalInterest:
                       type: string
                       example: "0.22759183"
+                  required:
+                      - annualInterestRate
+                      - asset
+                      - avgAnnualInterestRate
+                      - canRedeem
+                      - dailyInterestRate
+                      - freeAmount
+                      - freezeAmount
+                      - lockedAmount
+                      - productId
+                      - productName
+                      - redeemingAmount
+                      - todayPurchasedAmount
+                      - totalAmount
+                      - totalInterest
         '400':
           description: Bad Request
           content:
@@ -7408,7 +8224,7 @@ paths:
   /sapi/v1/lending/project/list:
     get:
       summary: Get Fixed/Activity Project List(USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7439,9 +8255,11 @@ paths:
                       example: "USDT"
                     displayPriority:
                       type: integer
+                      format: int64
                       example: 1
                     duration:
                       type: integer
+                      format: int64
                       example: 90
                     interestPerLot:
                       type: string
@@ -7454,15 +8272,19 @@ paths:
                       example: "100.00000000"
                     lotsLowLimit:
                       type: integer
+                      format: int64
                       example: 1
                     lotsPurchased:
                       type: integer
+                      format: int64
                       example: 74155
                     lotsUpLimit:
                       type: integer
+                      format: int64
                       example: 80000
                     maxLotsPerUser:
                       type: integer
+                      format: int64
                       example: 2000
                     needKyc:
                       type: boolean
@@ -7480,6 +8302,23 @@ paths:
                       example: "CUSTOMIZED_FIXED"
                     withAreaLimitation:
                       type: boolean
+                  required:
+                      - asset
+                      - displayPriority
+                      - duration
+                      - interestPerLot
+                      - interestRate
+                      - lotSize
+                      - lotsLowLimit
+                      - lotsPurchased
+                      - lotsUpLimit
+                      - maxLotsPerUser
+                      - needKyc
+                      - projectId
+                      - projectName
+                      - status
+                      - type
+                      - withAreaLimitation
         '400':
           description: Bad Request
           content:
@@ -7495,7 +8334,7 @@ paths:
   /sapi/v1/lending/customizedFixed/purchase:
     post:
       summary: Purchase Fixed/Activity Project (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7517,6 +8356,8 @@ paths:
                   purchaseId:
                     type: string
                     example: "18356"
+                required:
+                    - purchaseId
         '400':
           description: Bad Request
           content:
@@ -7532,7 +8373,7 @@ paths:
   /sapi/v1/lending/project/position/list:
     get:
       summary: Get Fixed/Activity Project Position (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7561,12 +8402,15 @@ paths:
                       type: boolean
                     createTimestamp:
                       type: integer
+                      format: int64
                       example: 1587010770000
                     duration:
                       type: integer
+                      format: int64
                       example: 14
                     endTime:
                       type: integer
+                      format: int64
                       example: 1588291200000
                     interest:
                       type: string
@@ -7576,9 +8420,11 @@ paths:
                       example: "0.05201250"
                     lot:
                       type: integer
+                      format: int64
                       example: 1
                     positionId:
                       type: integer
+                      format: int64
                       example: 51724
                     principal:
                       type: string
@@ -7591,6 +8437,7 @@ paths:
                       example: "USDT"
                     purchaseTime:
                       type: integer
+                      format: int64
                       example: 1587010771000
                     redeemDate:
                       type: string
@@ -7598,6 +8445,7 @@ paths:
                       example: "2020-05-01"
                     startTime:
                       type: integer
+                      format: int64
                       example: 1587081600000
                     status:
                       type: string
@@ -7605,6 +8453,24 @@ paths:
                     type:
                       type: string
                       example: "CUSTOMIZED_FIXED"
+                  required:
+                      - asset
+                      - canTransfer
+                      - createTimestamp
+                      - duration
+                      - endTime
+                      - interest
+                      - interestRate
+                      - lot
+                      - positionId
+                      - principal
+                      - projectId
+                      - projectName
+                      - purchaseTime
+                      - redeemDate
+                      - startTime
+                      - status
+                      - type
         '400':
           description: Bad Request
           content:
@@ -7620,7 +8486,7 @@ paths:
   /sapi/v1/lending/union/account:
     get:
       summary: Lending Account (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Savings
       parameters:
@@ -7654,6 +8520,11 @@ paths:
                         asset:
                           type: string
                           example: "USDT"
+                      required:
+                          - amount
+                          - amountInBTC
+                          - amountInUSDT
+                          - asset
                   totalAmountInBTC:
                     type: string
                     example: "0.01067982"
@@ -7672,6 +8543,14 @@ paths:
                   totalFlexibleInUSDT:
                     type: string
                     example: "77.13289230"
+                required:
+                    - positionAmountVos
+                    - totalAmountInBTC
+                    - totalAmountInUSDT
+                    - totalFixedAmountInBTC
+                    - totalFixedAmountInUSDT
+                    - totalFlexibleInBTC
+                    - totalFlexibleInUSDT
         '400':
           description: Bad Request
           content:
@@ -7691,7 +8570,7 @@ paths:
         - The time between startTime and endTime cannot be longer than 30 days.
         - If startTime and endTime are both not sent, then the last 30 days' data will be returned.
         
-        Weight: 1
+        Weigh(IP): 1
       tags:
         - Savings
       parameters:
@@ -7734,7 +8613,7 @@ paths:
         - The time between startTime and endTime cannot be longer than 30 days.
         - If startTime and endTime are both not sent, then the last 30 days' data will be returned.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Savings
       parameters:
@@ -7777,7 +8656,7 @@ paths:
         - The time between startTime and endTime cannot be longer than 30 days.
         - If startTime and endTime are both not sent, then the last 30 days' data will be returned.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Savings
       parameters:
@@ -7816,7 +8695,14 @@ paths:
                       example: "BUSD"
                     time:
                       type: integer
+                      format: int64
                       example: 1577233578000
+                  required:
+                      - asset
+                      - interest
+                      - lendingType
+                      - productName
+                      - time
         '400':
           description: Bad Request
           content:
@@ -7835,7 +8721,7 @@ paths:
       description: |-
         - PositionId is mandatory parameter for fixed position.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - Savings
       parameters:
@@ -7857,12 +8743,18 @@ paths:
                 properties:
                   dailyPurchaseId:
                     type: integer
+                    format: int64
                     example: 862290
                   success:
                     type: boolean
                   time:
                     type: integer
+                    format: int64
                     example: 1577233578000
+                required:
+                    - dailyPurchaseId
+                    - success
+                    - time
         '400':
           description: Bad Request
           content:
@@ -7878,7 +8770,7 @@ paths:
   /sapi/v1/mining/pub/algoList:
     get:
       summary: Acquiring Algorithm (MARKET_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Mining
       parameters:
@@ -7897,6 +8789,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -7911,13 +8804,24 @@ paths:
                           example: "sha256"
                         algoId:
                           type: integer
+                          format: int64
                           example: 1
                         poolIndex:
                           type: integer
+                          format: int64
                           example: 0
                         unit:
                           type: string
                           example: "h/s"
+                      required:
+                          - algoName
+                          - algoId
+                          - poolIndex
+                          - unit
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -7927,7 +8831,7 @@ paths:
   /sapi/v1/mining/pub/coinList:
     get:
       summary: Acquiring CoinName (MARKET_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - Mining
       parameters:
@@ -7946,6 +8850,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -7960,16 +8865,29 @@ paths:
                           example: "BTC"
                         coinId:
                           type: integer
+                          format: int64
                           example: 1
                         poolIndex:
                           type: integer
+                          format: int64
                           example: 0
                         algoId:
                           type: integer
+                          format: int64
                           example: 1
                         algoName:
                           type: string
                           example: "sha256"
+                      required:
+                          - coinName
+                          - coinId
+                          - poolIndex
+                          - algoId
+                          - algoName
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -7979,7 +8897,7 @@ paths:
   /sapi/v1/mining/worker/detail:
     get:
       summary: Request for Detail Miner List (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8001,6 +8919,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -8025,14 +8944,28 @@ paths:
                             properties:
                               time:
                                 type: integer
+                                format: int64
                                 example: 1587902400000
                               hashrate:
                                 type: string
                                 example: "0"
                               reject:
                                 type: integer
+                                format: int64
                                 example: 0
                                 description: Rejection Rate
+                            required:
+                                - time
+                                - hashrate
+                                - reject
+                      required:
+                          - workerName
+                          - type
+                          - hashrateDatas
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8048,7 +8981,7 @@ paths:
   /sapi/v1/mining/worker/list:
     get:
       summary: Request for Miner List (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8073,6 +9006,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -8093,30 +9027,53 @@ paths:
                               example: "2X73"
                             status:
                               type: integer
+                              format: int64
                               example: 3
                               description: "Status：1 valid, 2 invalid, 3 no longer valid"
                             hashRate:
                               type: integer
+                              format: int64
                               example: 0
                               description: Real-time rate
                             dayHashRate:
                               type: integer
+                              format: int64
                               example: 0
                               description: 24H Hashrate
                             rejectRate:
                               type: integer
+                              format: int64
                               example: 0
                               description: Real-time Rejection Rate
                             lastShareTime:
                               type: integer
+                              format: int64
                               example: 1587712919000
                               description: Last submission time
+                          required:
+                              - workerId
+                              - workerName
+                              - status
+                              - hashRate
+                              - dayHashRate
+                              - rejectRate
+                              - lastShareTime
                       totalNum:
                         type: integer
+                        format: int64
                         example: 18530
                       pageSize:
                         type: integer
+                        format: int64
                         example: 20
+                    required:
+                        - workerDatas
+                        - totalNum
+                        - pageSize
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8132,7 +9089,7 @@ paths:
   /sapi/v1/mining/payment/list:
     get:
       summary: Earnings List (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8158,6 +9115,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -8172,10 +9130,12 @@ paths:
                           properties:
                             time:
                               type: integer
+                              format: int64
                               example: 1586188800000
                               description: Mining date
                             type:
                               type: integer
+                              format: int64
                               example: 31
                               description: "0:Mining Wallet,5:Mining Address,7:Pool Savings,8:Transferred,31:Income Transfer ,32:Hashrate Resale-Mining Wallet 33:Hashrate Resale-Pool Savings"
                             hashTransfer:
@@ -8190,10 +9150,12 @@ paths:
                               description: Transferred Income   
                             dayHashRate:
                               type: integer
+                              format: int64
                               example: 129129903378244
                               description: Daily Hashrate
                             profitAmount:
                               type: number
+                              format: double
                               example: 8.6083060304
                               description: Earnings Amount
                             coinName:
@@ -8202,16 +9164,36 @@ paths:
                               description: Coin Type
                             status:
                               type: integer
+                              format: int32
                               example: 2
                               description: "Status：0:Unpaid, 1:Paying  2：Paid"
+                          required:
+                              - time
+                              - type
+                              - hashTransfer
+                              - transferAmount
+                              - dayHashRate
+                              - profitAmount
+                              - coinName
+                              - status
                       totalNum:
                         type: integer
+                        format: int64
                         example: 3
                         description: Total Rows
                       pageSize:
                         type: integer
+                        format: int64
                         example: 20
                         description: Rows per page
+                    required:
+                        - accountProfits
+                        - totalNum
+                        - pageSize
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8227,7 +9209,7 @@ paths:
   /sapi/v1/mining/payment/other:
     get:
       summary: Extra Bonus List (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8253,6 +9235,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -8267,6 +9250,7 @@ paths:
                           properties:
                             time:
                               type: integer
+                              format: int64
                               example: 1607443200000
                               description: Mining date
                             coinName:
@@ -8275,23 +9259,42 @@ paths:
                               description: Coin Name
                             type:
                               type: integer
+                              format: int32
                               example: 4
                               description: '1: Merged Mining, 2: Activity Bonus, 3:Rebate 4:Smart Pool 6:Income Transfer 7:Pool Savings'
                             profitAmount:
                               type: number
+                              format: double
                               example: 0.0011859
                             status:
                               type: integer
+                              format: int32
                               example: 2
                               description: '0:Unpaid, 1:Paying  2：Paid'
+                          required:
+                              - time
+                              - coinName
+                              - type
+                              - profitAmount
+                              - status
                       totalNum:
                         type: integer
+                        format: int64
                         example: 3
                         description: Total Rows
                       pageSize:
                         type: integer
+                        format: int64
                         example: 20
                         description: Rows per page
+                    required:
+                        - otherProfits
+                        - totalNum
+                        - pageSize
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8307,7 +9310,7 @@ paths:
   /sapi/v1/mining/hash-transfer/config/details/list:
     get:
       summary: Hashrate Resale List (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8328,6 +9331,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -8342,6 +9346,7 @@ paths:
                           properties:
                             configId:
                               type: integer
+                              format: int64
                               example: 168
                               description: Mining ID
                             poolUsername:
@@ -8358,26 +9363,49 @@ paths:
                               description: Transfer algorithm
                             hashRate:
                               type: integer
+                              format: int64
                               example: 5000000
                               description: Transferred Hashrate quantity
                             startDay:
                               type: integer
+                              format: int64
                               example: 20201210
                               description: Start date
                             endDay:
                               type: integer
+                              format: int64
                               example: 20210405
                               description: End date
                             status:
                               type: integer
+                              format: int32
                               example: 1
                               description: "0 Processing, 1：Cancelled, 2：Terminated "
+                          required:
+                              - configId
+                              - poolUsername
+                              - toPoolUsername
+                              - algoName
+                              - hashRate
+                              - startDay
+                              - endDay
+                              - status
                       totalNum:
                         type: integer
+                        format: int64
                         example: 21
                       pageSize:
                         type: integer
+                        format: int64
                         example: 200
+                    required:
+                        - configDetails
+                        - totalNum
+                        - pageSize
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8393,7 +9421,7 @@ paths:
   /sapi/v1/mining/hash-transfer/profit/details:
     get:
       summary: Hashrate Resale Details (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8416,6 +9444,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -8442,25 +9471,46 @@ paths:
                               description: Transfer algorithm
                             hashRate:
                               type: integer
+                              format: int64
                               example: 200000000000
                               description: Transferred Hashrate quantity
                             day:
                               type: integer
+                              format: int64
                               example: 20201213
                               description: Transfer date
                             amount:
                               type: number
+                              format: double
                               example: 0.2256872
                               description: Transfer income
                             coinName:
                               type: string
                               example: "BTC"
+                          required:
+                              - poolUsername
+                              - toPoolUsername
+                              - algoName
+                              - hashRate
+                              - day
+                              - amount
+                              - coinName
                       totalNum:
                         type: integer
+                        format: int64
                         example: 8
                       pageSize:
                         type: integer
+                        format: int64
                         example: 200
+                    required:
+                        - profitTransferDetails
+                        - totalNum
+                        - pageSize
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8476,7 +9526,7 @@ paths:
   /sapi/v1/mining/hash-transfer/config:
     post:
       summary: Hashrate Resale Request (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8501,14 +9551,20 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
                     example: ""
                   data:
                     type: integer
+                    format: int64
                     example: 171
                     description: Mining Account
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8524,7 +9580,7 @@ paths:
   /sapi/v1/mining/hash-transfer/config/cancel:
     post:
       summary: Cancel Hashrate Resale configuration (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8545,12 +9601,17 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
                     example: ""
                   data:
                     type: boolean
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8566,7 +9627,7 @@ paths:
   /sapi/v1/mining/statistics/user/status:
     get:
       summary: Statistic List (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8587,6 +9648,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -8602,9 +9664,11 @@ paths:
                         example: "214289268068874127.65000000"
                       validNum:
                         type: integer
+                        format: int64
                         example: 0
                       invalidNum:
                         type: integer
+                        format: int64
                         example: 17562
                       profitToday:
                         type: object
@@ -8618,6 +9682,10 @@ paths:
                           BCH:
                             type: string
                             example: "106.61586001"
+                        required:
+                            - BTC
+                            - BSV
+                            - BCH
                       profitYesterday:
                         type: object
                         properties:
@@ -8630,6 +9698,10 @@ paths:
                           BCH:
                             type: string
                             example: "106.61586001"
+                        required:
+                            - BTC
+                            - BSV
+                            - BCH
                       userName:
                         type: string
                         example: "test"
@@ -8639,6 +9711,20 @@ paths:
                       algo:
                         type: string
                         example: "sha256"
+                    required:
+                        - fifteenMinHashRate
+                        - dayHashRate
+                        - validNum
+                        - invalidNum
+                        - profitToday
+                        - profitYesterday
+                        - userName
+                        - unit
+                        - algo
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8654,7 +9740,7 @@ paths:
   /sapi/v1/mining/statistics/user/list:
     get:
       summary: Account List (USER_DATA)
-      description: 'Weight: 5'
+      description: 'Weight(IP): 5'
       tags:
         - Mining
       parameters:
@@ -8675,6 +9761,7 @@ paths:
                 properties:
                   code:
                     type: integer
+                    format: int64
                     example: 0
                   msg:
                     type: string
@@ -8697,6 +9784,7 @@ paths:
                             properties:
                               time:
                                 type: integer
+                                format: int64
                                 example: 1585267200000
                               hashrate:
                                 type: string
@@ -8704,6 +9792,18 @@ paths:
                               reject:
                                 type: string
                                 example: "0.00000000"
+                            required:
+                                - time
+                                - hashrate
+                                - reject
+                      required:
+                          - type
+                          - userName
+                          - list
+                required:
+                    - code
+                    - msg
+                    - data
         '400':
           description: Bad Request
           content:
@@ -8719,7 +9819,7 @@ paths:
   /sapi/v1/blvt/tokenInfo:
     get:
       summary: BLVT Info (MARKET_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - BLVT
       parameters:
@@ -8765,6 +9865,10 @@ paths:
                           notionalValue: 
                             type: string
                             example: "-22871089.96704"
+                        required:
+                            - symbol
+                            - amount
+                            - notionalValue
                     nav: 
                       type: string
                       example: "4.79"
@@ -8789,9 +9893,26 @@ paths:
                     dailyRedeemLimit: 
                       type: string
                       example: "1000000.00"
-                    timstamp: 
-                      type: number
+                    timestamp: 
+                      type: integer
+                      format: int64
                       example: 1583127900000
+                  required:
+                      - tokenName
+                      - description
+                      - underlying
+                      - tokenIssued
+                      - basket
+                      - currentBaskets
+                      - nav
+                      - realLeverage
+                      - fundingRate
+                      - dailyManagementFee
+                      - purchaseFeePct
+                      - dailyPurchaseLimit
+                      - redeemFeePct
+                      - dailyRedeemLimit
+                      - timestamp
         '400':
           description: Bad Request
           content:
@@ -8801,7 +9922,7 @@ paths:
   /sapi/v1/blvt/subscribe:
     post:
       summary: Subscribe BLVT (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - BLVT
       parameters:
@@ -8812,7 +9933,7 @@ paths:
           required: true
           schema:
             type: number
-            format: float
+            format: double
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
         - $ref: '#/components/parameters/signature'
@@ -8828,6 +9949,7 @@ paths:
                 properties: 
                   id: 
                     type: number
+                    format: double
                     example: 123
                   status: 
                     type: string
@@ -8844,9 +9966,17 @@ paths:
                     type: string
                     example: "9.99999995"
                     description: subscription cost in usdt
-                  timstamp: 
-                    type: number
+                  timestamp: 
+                    type: integer
+                    format: int64
                     example: 1600249972899
+                required:
+                    - id
+                    - status
+                    - tokenName
+                    - amount
+                    - cost
+                    - timestamp
         '400':
           description: Bad Request
           content:
@@ -8865,7 +9995,7 @@ paths:
       description: |-
         - Only the data of the latest 90 days is available
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - BLVT
       parameters:
@@ -8874,6 +10004,7 @@ paths:
           in: query
           schema:
             type: integer
+            format: int64
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
         - $ref: '#/components/parameters/limit'
@@ -8892,6 +10023,7 @@ paths:
                 properties: 
                   id: 
                     type: number
+                    format: double
                     example: 1
                   tokenName: 
                     type: string
@@ -8912,9 +10044,18 @@ paths:
                     type: string
                     example: "9.99999991"
                     description: Subscription cost in usdt
-                  timstamp: 
-                    type: number
+                  timestamp: 
+                    type: integer
+                    format: int64
                     example: 1599127217916
+                required:
+                    - id
+                    - tokenName
+                    - amount
+                    - nav
+                    - fee
+                    - totalCharge
+                    - timestamp
         '400':
           description: Bad Request
           content:
@@ -8930,7 +10071,7 @@ paths:
   /sapi/v1/blvt/redeem:
     post:
       summary: Redeem BLVT (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - BLVT
       parameters:
@@ -8951,6 +10092,7 @@ paths:
                 properties: 
                   id: 
                     type: number
+                    format: double
                     example: 123
                   status: 
                     type: string
@@ -8967,9 +10109,17 @@ paths:
                     type: string
                     example: "10.05022099"
                     description: Redemption value in usdt
-                  timstamp: 
-                    type: number
+                  timestamp: 
+                    type: integer
+                    format: int64
                     example: 1600250279614
+                required:
+                    - id
+                    - status
+                    - tokenName
+                    - redeemAmount
+                    - amount
+                    - timestamp
         '400':
           description: Bad Request
           content:
@@ -8988,7 +10138,7 @@ paths:
       description: |-
         - Only the data of the latest 90 days is available
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - BLVT
       parameters:
@@ -8997,12 +10147,14 @@ paths:
           in: query
           schema:
             type: integer
+            format: int64
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
         - name: limit
           in: query
           schema:
             type: integer
+            format: int32
           description: 'default 1000, max 1000'
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -9021,6 +10173,7 @@ paths:
                   properties: 
                     id: 
                       type: number
+                      format: double
                       example: 1
                     tokenName: 
                       type: string
@@ -9041,9 +10194,18 @@ paths:
                       type: string
                       example: "9.94602604"
                       description: Net redemption value in usdt
-                    timstamp: 
-                      type: number
+                    timestamp: 
+                      type: integer
+                      format: int64
                       example: 1599128003050
+                  required:
+                      - id
+                      - tokenName
+                      - amount
+                      - nav
+                      - fee
+                      - netProceed
+                      - timestamp
         '400':
           description: Bad Request
           content:
@@ -9059,7 +10221,7 @@ paths:
   /sapi/v1/blvt/userLimit:
     get:
       summary: BLVT User Limit Info (USER_DATA)
-      description: 'Weight: 1'
+      description: 'Weight(IP): 1'
       tags:
         - BLVT
       parameters:
@@ -9090,6 +10252,10 @@ paths:
                       type: string
                       example: "1000"
                       description: USDT
+                  required:
+                      - tokenName
+                      - userDailyTotalPurchaseLimit
+                      - userDailyTotalRedeemLimit
         '400':
           description: Bad Request
           content:
@@ -9108,7 +10274,7 @@ paths:
       description: |-
         Get metadata about all swap pools.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - BSwap
       security:
@@ -9124,7 +10290,8 @@ paths:
                   type: object
                   properties: 
                     poolId: 
-                      type: number
+                      type: integer
+                      format: int64
                       example: 2
                     poolName: 
                       type: string
@@ -9133,9 +10300,15 @@ paths:
                       type: array
                       items: 
                         type: string
+                        minItems: 2
+                        maxItems: 2
                       example:
                         - BUSD
                         - USDT
+                  required:
+                      - poolId
+                      - poolName
+                      - assets
         '400':
           description: Bad Request
           content:
@@ -9148,9 +10321,9 @@ paths:
       description: |-
         Get liquidity information and user share of a pool.
         
-        Weight:\
-        `1`  for one pool\
-        `10` when the poolId parameter is omitted
+        Weight(IP):\
+        `1`  for one pool;\
+        `10` when the poolId parameter is omitted;
       tags:
         - BSwap
       parameters:
@@ -9171,41 +10344,65 @@ paths:
                   type: object
                   properties: 
                     poolId: 
-                      type: number
+                      type: integer
+                      format: int64
                       example: 2
                     poolNmae: 
                       type: string
                       example: "BUSD/USDT"
                     updateTime: 
-                      type: number
+                      type: integer
+                      format: int64
                       example: 1565769342148
                     liquidity: 
                       type: object
                       properties: 
                         BUSD: 
                           type: number
+                          format: double
                           example: 100000315.79
                         USDT: 
                           type: number
+                          format: double
                           example: 99999245.54
+                      required:
+                          - BUSD
+                          - USDT
                     share: 
                       type: object
                       properties: 
                         shareAmount: 
                           type: number
+                          format: double
                           example: 12415
                         sharePercentage: 
                           type: number
+                          format: double
                           example: 0.00006207
                         asset: 
                           type: object
                           properties: 
                             BUSD: 
                               type: number
+                              format: double
                               example: 6207.02
                             USDT: 
                               type: number
+                              format: double
                               example: 6206.95
+                          required:
+                              - BUSD
+                              - USDT
+                      required:
+                          - shareAmount
+                          - sharePercentage
+                          - asset
+                  required:
+                      - poolId
+                      - poolNmae
+                      - updateTime
+                      - liquidity
+                      - share
         '400':
           description: Bad Request
           content:
@@ -9224,7 +10421,7 @@ paths:
       description: |-
         Add liquidity to a pool.
         
-        Weight: 2
+        Weight(UID): 1000 (Additional: 3 times one second)
       tags:
         - BSwap
       parameters:
@@ -9245,8 +10442,11 @@ paths:
                 type: object
                 properties: 
                   operationId: 
-                    type: number
+                    type: integer
+                    format: int64
                     example: 12341
+                required:
+                    - operationId
         '400':
           description: Bad Request
           content:
@@ -9265,7 +10465,7 @@ paths:
       description: |-
         Remove liquidity from a pool, `type` include `SINGLE` and `COMBINATION`, asset is mandatory for single asset removal
         
-        Weight: 2
+        Weight(UID): 1000 (Additional: 3 times one second)
       tags:
         - BSwap
       parameters:
@@ -9289,7 +10489,7 @@ paths:
           required: true
           schema:
             type: number
-            format: float
+            format: double
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
         - $ref: '#/components/parameters/signature'
@@ -9304,8 +10504,11 @@ paths:
                 type: object
                 properties: 
                   operationId: 
-                    type: number
+                    type: integer
+                    format: int64
                     example: 12341
+                required:
+                    - operationId
         '400':
           description: Bad Request
           content:
@@ -9324,7 +10527,7 @@ paths:
       description: |-
         Get liquidity operation (add/remove) records.
         
-        Weight: 2
+        Weight(UID): 3000
       tags:
         - BSwap
       parameters:
@@ -9332,6 +10535,7 @@ paths:
           in: query
           schema:
             type: integer
+            format: int64
         - $ref: '#/components/parameters/optionalPoolId'
         - name: operation
           in: query
@@ -9357,10 +10561,12 @@ paths:
                   type: object
                   properties: 
                     operationId: 
-                      type: number
+                      type: integer
+                      format: int64
                       example: 12341
                     poolId: 
-                      type: number
+                      type: integer
+                      format: int64
                       example: 2
                     poolName: 
                       type: string
@@ -9370,15 +10576,25 @@ paths:
                       example: "ADD"
                       description: '"ADD" or "REMOVE"'
                     status: 
-                      type: number
+                      type: integer
+                      format: int32
                       example: 1
-                      description: '0: pending, 1: success, 2: failed'
+                      description: "0: pending, 1: success, 2: failed"
                     updateTime: 
-                      type: number
+                      type: integer
+                      format: int64
                       example: 1565769342148
                     shareAmount: 
                       type: string
                       example: "10.1"
+                  required:
+                      - operationId
+                      - poolId
+                      - poolName
+                      - operation
+                      - status
+                      - updateTime
+                      - shareAmount
         '400':
           description: Bad Request
           content:
@@ -9401,7 +10617,7 @@ paths:
 
         Please be noted the quote is for reference only, the actual price will change as the liquidity changes, it's recommended to swap immediate after request a quote for slippage prevention.
         
-        Weight: 2
+        Weight(UID): 150
       tags:
         - BSwap
       parameters:
@@ -9429,19 +10645,32 @@ paths:
                     example: "BUSD"
                   quoteQty: 
                     type: number
+                    format: double
                     example: 300000
                   baseQty: 
                     type: number
+                    format: double
                     example: 299975
                   price: 
                     type: number
+                    format: double
                     example: 1.00008334
                   slippage: 
                     type: number
+                    format: double
                     example: 0.00007245
                   fee: 
                     type: number
+                    format: double
                     example: 120
+                required:
+                    - quoteAsset
+                    - baseAsset
+                    - quoteQty
+                    - baseQty
+                    - price
+                    - slippage
+                    - fee
         '400':
           description: Bad Request
           content:
@@ -9460,7 +10689,7 @@ paths:
       description: |-
         Swap `quoteAsset` for `baseAsset`.
         
-        Weight: 2
+        Weight(UID): 1000 (Additional: 3 times one second)
       tags:
         - BSwap
       parameters:
@@ -9481,8 +10710,11 @@ paths:
                 type: object
                 properties: 
                   swapId: 
-                    type: number
+                    type: integer
+                    format: int64
                     example: 2314
+                required:
+                    - swapId
         '400':
           description: Bad Request
           content:
@@ -9500,7 +10732,7 @@ paths:
       description: |-
         Get swap history.
         
-        Weight: 2
+        Weight(UID): 3000
       tags:
         - BSwap
       parameters:
@@ -9508,6 +10740,7 @@ paths:
           in: query
           schema:
             type: integer
+            format: int64
         - $ref: '#/components/parameters/startTime'
         - $ref: '#/components/parameters/endTime'
         - name: status
@@ -9515,6 +10748,7 @@ paths:
           description: '0: pending for swap, 1: success, 2: failed'
           schema:
             type: integer
+            format: int32
             enum: [0,1,2]
         - name: quoteAsset
           in: query
@@ -9530,6 +10764,7 @@ paths:
           in: query
           schema:
             type: integer
+            format: int32
           description: 'default 3, max 100'
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
@@ -9547,15 +10782,18 @@ paths:
                   type: object
                   properties: 
                     swapId: 
-                      type: number
+                      type: integer
+                      format: int64
                       example: 2314
                     swapTime: 
-                      type: number
+                      type: integer
+                      format: int64
                       example: 1565770342148
-                      description: "0: pending, 1: success, 2: failed"
                     status: 
-                      type: number
+                      type: integer
+                      format: int32
                       example: 0
+                      description: "0: pending, 1: success, 2: failed"
                     quoteAsset: 
                       type: string
                       example: "USDT"
@@ -9564,16 +10802,273 @@ paths:
                       example: "BUSD"
                     quoteQty: 
                       type: number
+                      format: double
                       example: 300000
                     baseQty: 
                       type: number
+                      format: double
                       example: 299975
                     price: 
                       type: number
+                      format: double
                       example: 1.00008334
                     fee: 
                       type: number
+                      format: double
                       example: 120
+                  required:
+                      - swapId
+                      - swapTime
+                      - status
+                      - quoteAsset
+                      - baseAsset
+                      - quoteQty
+                      - baseQty
+                      - price
+                      - fee
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+  /sapi/v1/bswap/poolConfigure:
+    get:
+      summary: Pool Configure (USER_DATA)
+      description: 'Weight(IP): 150'
+      tags:
+        - BSwap
+      parameters:
+        - name: poolId
+          in: query
+          schema:
+            type: integer
+            format: int64
+            example: 2
+        - $ref: '#/components/parameters/recvWindow'
+        - $ref: '#/components/parameters/timestamp'
+        - $ref: '#/components/parameters/signature'
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Pool Information
+          content:
+            application/json:
+              schema:
+                type: array
+                items: 
+                  type: object
+                  properties: 
+                    poolId: 
+                      type: integer
+                      format: int64
+                      example: 2
+                    poolNmae: 
+                      type: string
+                      example: "BUSD/USDT"
+                    updateTime: 
+                      type: integer
+                      format: int64
+                      example: 1565769342148
+                    liquidity: 
+                      type: object
+                      properties: 
+                        constantA: 
+                          type: integer
+                          format: int64
+                          example: 2000
+                          description: '"NA" if pool is an innovation pool'
+                        minRedeemShare: 
+                          type: number
+                          format: double
+                          example: 0.1
+                        slippageTolerance: 
+                          type: number
+                          example: 0.2
+                          format: double
+                          description: The swap proceeds only when the slippage is within the set range
+                      required:
+                          - constantA
+                          - minRedeemShare
+                          - slippageTolerance
+                    assetConfigure: 
+                      type: object
+                      properties: 
+                        BUSD: 
+                          type: object
+                          properties: 
+                            minAdd: 
+                              type: integer
+                              format: int64
+                              example: 10
+                            maxAdd: 
+                              type: integer
+                              format: int64
+                              example: 20
+                            minSwap: 
+                              type: integer
+                              format: int64
+                              example: 10
+                            maxSwap: 
+                              type: integer
+                              format: int64
+                              example: 30
+                          required:
+                              - minAdd
+                              - maxAdd
+                              - minSwap
+                              - maxSwap
+                        USDT: 
+                          type: object
+                          properties: 
+                            minAdd: 
+                              type: integer
+                              format: int64
+                              example: 10
+                            maxAdd: 
+                              type: integer
+                              format: int64
+                              example: 20
+                            minSwap: 
+                              type: integer
+                              format: int64
+                              example: 10
+                            maxSwap: 
+                              type: integer
+                              format: int64
+                              example: 30
+                          required:
+                              - minAdd
+                              - maxAdd
+                              - minSwap
+                              - maxSwap
+                      required:
+                          - BUSD
+                          - USDT
+                  required:
+                      - poolId
+                      - poolNmae
+                      - updateTime
+                      - liquidity
+                      - assetConfigure
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+  /sapi/v1/bswap/addLiquidityPreview:
+    get:
+      summary: Add Liquidity Preview (USER_DATA)
+      description: |-
+        Calculate expected share amount for adding liquidity in single or dual token.
+        
+        Weight(IP): 150
+      tags:
+        - BSwap
+      parameters:
+        - name: poolId
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 2
+        - name: type
+          in: query
+          description: '"SINGLE" for adding a single token;"COMBINATION" for adding dual tokens'
+          required: true
+          schema:
+            type: string
+            enum: [SINGLE, COMBINATION]
+            example: 'SINGLE'
+        - $ref: '#/components/parameters/quoteAsset'
+        - $ref: '#/components/parameters/quoteQty'
+        - $ref: '#/components/parameters/recvWindow'
+        - $ref: '#/components/parameters/timestamp'
+        - $ref: '#/components/parameters/signature'
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Add Liquidity Preview
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/bswapAddLiquidityPreviewCombination'
+                  - $ref: '#/components/schemas/bswapAddLiquidityPreviewSingle'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+  /sapi/v1/bswap/removeLiquidityPreview:
+    get:
+      summary: Remove Liquidity Preview (USER_DATA)
+      description: |-
+        Calculate the expected asset amount of single token redemption or dual token redemption.
+        
+        Weight(IP): 150
+      tags:
+        - BSwap
+      parameters:
+        - name: poolId
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 2
+        - name: type
+          in: query
+          description: 'Type is "SINGLE", remove and obtain a single token;Type is "COMBINATION", remove and obtain dual token.'
+          required: true
+          schema:
+            type: string
+            enum: [SINGLE, COMBINATION]
+            example: 'SINGLE'
+        - $ref: '#/components/parameters/quoteAsset'
+        - name: shareAmount
+          in: query
+          required: true
+          schema:
+            type: number
+            format: double
+        - $ref: '#/components/parameters/recvWindow'
+        - $ref: '#/components/parameters/timestamp'
+        - $ref: '#/components/parameters/signature'
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Remove Liquidity Preview
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/bswapRmvLiquidityPreviewCombination'
+                  - $ref: '#/components/schemas/bswapRmvLiquidityPreviewSingle'
         '400':
           description: Bad Request
           content:
@@ -9593,7 +11088,7 @@ paths:
         - If startTimestamp and endTimestamp are not sent, the recent 30-day data will be returned.
         - The max interval between startTimestamp and endTimestamp is 30 days.
         
-        Weight: 1
+        Weight(IP): 1
       tags:
         - C2C
       parameters:
@@ -9607,17 +11102,20 @@ paths:
           description: UTC timestamp in ms
           schema:
             type: integer
+            format: int64
         - name: endTimestamp
           in: query
           description: UTC timestamp in ms
           schema:
             type: integer
+            format: int64
         - $ref: '#/components/parameters/page'
         - name: rows
           in: query
           description: default 100, max 100
           schema:
             type: integer
+            format: int32
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
         - $ref: '#/components/parameters/signature'
@@ -9677,6 +11175,7 @@ paths:
                           description: PENDING, TRADING, BUYER_PAYED, DISTRIBUTING, COMPLETED, IN_APPEAL, CANCELLED, CANCELLED_BY_SYSTEM
                         createTime: 
                           type: integer
+                          format: int64
                           example: 1619361369000
                         commission: 
                           type: string
@@ -9688,11 +11187,33 @@ paths:
                         advertisementRole: 
                           type: string
                           example: "TAKER"
+                      required:
+                          - orderNumber
+                          - advNo
+                          - tradeType
+                          - asset
+                          - fiat
+                          - fiatSymbol
+                          - amount
+                          - totalPrice
+                          - unitPrice
+                          - orderStatus
+                          - createTime
+                          - commission
+                          - counterPartNickName
+                          - advertisementRole
                   total: 
                     type: integer
+                    format: int32
                     example: 1
                   success: 
                     type: boolean
+                required:
+                    - code
+                    - message
+                    - data
+                    - total
+                    - success
         '400':
           description: Bad Request
           content:
@@ -9721,14 +11242,15 @@ components:
       required: true
       schema:
         type: number
-        format: float
+        format: double
         example: '1.01'
     current:
       name: current
       in: query
       description: Current querying page. Start from 1. Default:1
       schema:
-        type: number
+        type: integer
+        format: int32
         example: 1
     optionalCoin:
       name: coin
@@ -9760,6 +11282,7 @@ components:
       description: Default:10 Max:100
       schema:
         type: integer
+        format: int32
         example: 100
     symbol:
       name: symbol
@@ -9788,6 +11311,7 @@ components:
       description: Default 500; max 1000.
       schema:
         type: integer
+        format: int32
         example: 500
     listenKey:
       name: listenKey
@@ -9802,23 +11326,27 @@ components:
       description: Trade id to fetch from. Default gets most recent trades.
       schema:
         type: integer
+        format: int64
     offset:
       name: offset
       in: query
       schema:
         type: integer
+        format: int32
     orderId:
       name: orderId
       in: query
       description: Order id
       schema:
         type: integer
+        format: int64
     orderListId:
       name: orderListId
       in: query
       description: Order list id
       schema:
         type: integer
+        format: int64
     origClientOrderId:
       name: origClientOrderId
       in: query
@@ -9857,12 +11385,14 @@ components:
       description: UTC timestamp in ms
       schema:
         type: integer
+        format: int64
     endTime:
       name: endTime
       in: query
       description: UTC timestamp in ms
       schema:
         type: integer
+        format: int64
     price:
       name: price
       in: query
@@ -9870,34 +11400,35 @@ components:
       description: Order price
       schema:
         type: number
-        format: float
+        format: double
     optionalPrice:
       name: price
       in: query
       description: Order price
       schema:
         type: number
-        format: float
+        format: double
     quantity:
       name: quantity
       in: query
       required: true
       schema:
         type: number
-        format: float
+        format: double
     optionalQuantity:
       name: quantity
       in: query
       description: Order quantity
       schema:
         type: number
-        format: float
+        format: double
     recvWindow:
       name: recvWindow
       in: query
       description: The value cannot be greater than 60000
       schema:
         type: integer
+        format: int64
         example: 5000
     timestamp:
       name: timestamp
@@ -9906,6 +11437,7 @@ components:
       description: UTC timestamp in ms
       schema:
         type: integer
+        format: int64
     timeInForce:
       name: timeInForce
       in: query
@@ -9919,6 +11451,7 @@ components:
       required: true
       schema:
         type: integer
+        format: int64
     orderType:
       name: type
       in: query
@@ -9949,7 +11482,7 @@ components:
       description: Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.
       schema:
         type: number
-        format: float
+        format: double
         example: 20.01
     isIsolatedMargin:
       name: isIsolated
@@ -9999,6 +11532,7 @@ components:
       in: query
       schema:
         type: integer
+        format: int64
         example: 1626144956000
     page:
       name: page
@@ -10006,6 +11540,7 @@ components:
       description: Default 1
       schema:
         type: integer
+        format: int32
         example: 1
     rows:
       name: rows
@@ -10013,6 +11548,7 @@ components:
       description: Default 100, max 500
       schema:
         type: integer
+        format: int32
         example: 300
     quoteOrderQty:
       name: quoteOrderQty
@@ -10020,14 +11556,14 @@ components:
       description: Quote quantity
       schema:
         type: number
-        format: float
+        format: double
     icebergQty:
       name: icebergQty
       in: query
       description: Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.
       schema:
         type: number
-        format: float
+        format: double
     flexibleProductStatus:
       name: status
       in: query
@@ -10152,25 +11688,29 @@ components:
       in: query
       description: Page number, default is first page, start form 1
       schema:
-        type: string
+        type: integer
+        format: int32
     sort:
       name: sort
       in: query
       description: sort sequence（default=0）0 positive sequence, 1 negative sequence
       schema:
         type: integer
+        format: int32
     sortColumn:
       name: sortColumn
       in: query
       description: 'Sort by( default 1): 1: miner name, 2: real-time computing power, 3: daily average computing power, 4: real-time rejection rate, 5: last submission time'
       schema:
         type: integer
+        format: int32
     workerStatus:
       name: workerStatus
       in: query
       description: miners status（default=0）0 all, 1 valid, 2 invalid, 3 failure
       schema:
         type: integer
+        format: int32
     startDate:
       name: startDate
       in: query
@@ -10236,11 +11776,13 @@ components:
       required: true
       schema:
         type: integer
+        format: int64
     optionalPoolId:
       name: poolId
       in: query
       schema:
         type: integer
+        format: int64
     quoteAsset:    
       name: quoteAsset
       in: query
@@ -10261,7 +11803,7 @@ components:
       required: true
       schema:
         type: number
-        format: float
+        format: double
     subAccountEmail:
       name: email
       in: query
@@ -10345,7 +11887,7 @@ components:
       in: query
       schema:
         type: number
-        format: float
+        format: double
     stopClientOrderId:
       name: stopClientOrderId
       in: query
@@ -10358,20 +11900,20 @@ components:
       required: true
       schema:
         type: number
-        format: float
+        format: double
     stopLimitPrice:      
       name: stopLimitPrice
       in: query
       description: 'If provided, stopLimitTimeInForce is required.'
       schema:
         type: number
-        format: float
+        format: double
     stopIcebergQty:      
       name: stopIcebergQty
       in: query
       schema:
         type: number
-        format: float
+        format: double
     stopLimitTimeInForce:      
       name: stopLimitTimeInForce
       in: query
@@ -10384,15 +11926,19 @@ components:
       properties:
         makerCommission:
           type: integer
+          format: int64
           example: 15
         takerCommission:
           type: integer
+          format: int64
           example: 15
         buyerCommission:
           type: integer
+          format: int64
           example: 0
         sellerCommission:
           type: integer
+          format: int64
           example: 0
         canTrade:
           type: boolean
@@ -10402,6 +11948,7 @@ components:
           type: boolean
         updateTime:
           type: integer
+          format: int64
           example: 123456789
         accountType:
           type: string
@@ -10420,6 +11967,21 @@ components:
               locked:
                 type: string
                 example: "0.00000000"
+            required:
+                - asset
+                - free
+                - locked
+      required:
+          - makerCommission
+          - takerCommission
+          - buyerCommission
+          - sellerCommission
+          - canTrade
+          - canWithdraw
+          - canDeposit
+          - updateTime
+          - accountType
+          - balances
     order:
       type: object
       properties:
@@ -10431,29 +11993,27 @@ components:
           example: "msXkySR3u5uYwpvRMFsi3u"
         orderId:
           type: integer
+          format: int64
           example: 28
         orderListId:
           type: integer
+          format: int64
           description: Unless OCO, value will be -1
           example: -1
         clientOrderId:
           type: string
           example: "6gCrw2kRUAF9CvJDGP16IP"
         price:
-          type: number
-          format: float
+          type: string
           example: "1.00000000"
         origQty:
-          type: number
-          format: float
+          type: string
           example: "10.00000000"
         executedQty:
-          type: number
-          format: float
+          type: string
           example: "10.00000000"
         cummulativeQuoteQty:
-          type: number
-          format: float
+          type: string
           example: "10.00000000"
         status:
           type: string
@@ -10467,6 +12027,298 @@ components:
         side:
           type: string
           example: "SELL"
+      required:
+          - symbol
+          - origClientOrderId
+          - orderId
+          - orderListId
+          - clientOrderId
+          - price
+          - origQty
+          - executedQty
+          - cummulativeQuoteQty
+          - status
+          - timeInForce
+          - type
+          - side
+    ocoOrder:
+      type: object
+      properties:
+        orderListId: 
+          type: integer
+          format: int64
+          example: 1929
+        contingencyType: 
+          type: string
+          example: "OCO"
+        listStatusType: 
+          type: string
+          example: "ALL_DONE"
+        listOrderStatus: 
+          type: string
+          example: "ALL_DONE"
+        listClientOrderId: 
+          type: string
+          example: "C3wyj4WVEktd7u9aVBRXcN"
+        transactionTime: 
+          type: integer
+          format: int64
+          example: 1574040868128
+        symbol: 
+          type: string
+          example: "BNBBTC"
+        orders: 
+          type: array
+          items: 
+            type: object
+            properties: 
+              symbol: 
+                type: string
+              orderId: 
+                type: integer
+                format: int64
+              clientOrderId: 
+                type: string
+            required:
+                - symbol
+                - orderId
+                - clientOrderId
+          example:
+            - symbol: "BNBBTC"
+              orderId: 2
+              clientOrderId: "pO9ufTiFGg3nw2fOdgeOXa"
+            - symbol: "BNBBTC"
+              orderId: 3
+              clientOrderId: "TXOvglzXuaubXAaENpaRCB"
+        orderReports: 
+          type: array
+          items: 
+            type: object
+            properties: 
+              symbol: 
+                type: string
+              origClientOrderId:
+                type: string
+              orderId: 
+                type: integer
+                format: int64
+              orderListId: 
+                type: integer
+                format: int64
+              clientOrderId: 
+                type: string
+              price: 
+                type: string
+              origQty: 
+                type: string
+              executedQty: 
+                type: string
+              cummulativeQuoteQty: 
+                type: string
+              status: 
+                type: string
+              timeInForce: 
+                type: string
+              type: 
+                type: string
+              side: 
+                type: string
+              stopPrice: 
+                type: string
+            required:
+                - symbol
+                - origClientOrderId
+                - orderId
+                - orderListId
+                - clientOrderId
+                - price
+                - origQty
+                - executedQty
+                - cummulativeQuoteQty
+                - status
+                - timeInForce
+                - type
+                - side
+                - stopPrice
+          example:
+            - symbol: "BNBBTC"
+              origClientOrderId: "pO9ufTiFGg3nw2fOdgeOXa"
+              orderId: 2
+              orderListId: 0
+              clientOrderId: "unfWT8ig8i0uj6lPuYLez6"
+              price: "1.00000000"
+              origQty: "10.00000000"
+              executedQty: "0.00000000"
+              cummulativeQuoteQty: "0.00000000"
+              status: "CANCELED"
+              timeInForce: "GTC"
+              type: "STOP_LOSS_LIMIT"
+              side: "SELL"
+              stopPrice: "1.00000000"
+            - symbol: "BNBBTC"
+              origClientOrderId: "TXOvglzXuaubXAaENpaRCB"
+              orderId: 3
+              orderListId: 0
+              clientOrderId: "unfWT8ig8i0uj6lPuYLez6"
+              price: "3.00000000"
+              origQty: "10.00000000"
+              executedQty: "0.00000000"
+              cummulativeQuoteQty: "0.00000000"
+              status: "CANCELED"
+              timeInForce: "GTC"
+              type: "LIMIT_MAKER"
+              side: "SELL"
+      required:
+          - orderListId
+          - contingencyType
+          - listStatusType
+          - listOrderStatus
+          - listClientOrderId
+          - transactionTime
+          - symbol
+          - orders
+          - orderReports
+    marginOcoOrder:
+      type: object
+      properties:
+        orderListId: 
+          type: integer
+          format: int64
+          example: 0
+        contingencyType: 
+          type: string
+          example: "OCO"
+        listStatusType: 
+          type: string
+          example: "ALL_DONE"
+        listOrderStatus: 
+          type: string
+          example: "ALL_DONE"
+        listClientOrderId: 
+          type: string
+          example: "C3wyj4WVEktd7u9aVBRXcN"
+        transactionTime: 
+          type: integer
+          format: int64
+          example: 1574040868128
+        symbol: 
+          type: string
+          example: "BNBUSDT"
+        isIsolated: 
+          type: boolean
+          example: false
+        orders: 
+          type: array
+          items: 
+            type: object
+            properties: 
+              symbol: 
+                type: string
+              orderId: 
+                type: integer
+                format: int64
+              clientOrderId: 
+                type: string
+            required:
+                - symbol
+                - orderId
+                - clientOrderId
+            example:
+              - symbol: "BNBUSDT"
+                orderId: 2
+                clientOrderId: "pO9ufTiFGg3nw2fOdgeOXa"
+              - symbol: "BNBUSDT"
+                orderId: 3
+                clientOrderId: "TXOvglzXuaubXAaENpaRCB"
+        orderReports: 
+          type: array
+          items: 
+            type: object
+            properties: 
+              symbol: 
+                type: string
+              origClientOrderId:
+                type: string
+              orderId: 
+                type: integer
+                format: int64
+              orderListId: 
+                type: integer
+                format: int64
+              clientOrderId: 
+                type: string
+              price: 
+                type: string
+              origQty: 
+                type: string
+              executedQty: 
+                type: string
+              cummulativeQuoteQty: 
+                type: string
+              status: 
+                type: string
+              timeInForce: 
+                type: string
+              type: 
+                type: string
+              side: 
+                type: string
+              stopPrice: 
+                type: string
+            required:
+                - symbol
+                - origClientOrderId
+                - orderId
+                - orderListId
+                - clientOrderId
+                - price
+                - origQty
+                - executedQty
+                - cummulativeQuoteQty
+                - status
+                - timeInForce
+                - type
+                - side
+                - stopPrice
+            example:
+              - symbol: "BNBUSDT"
+                origClientOrderId: "pO9ufTiFGg3nw2fOdgeOXa"
+                orderId: 2
+                orderListId: 0
+                clientOrderId: "unfWT8ig8i0uj6lPuYLez6"
+                price: "1.00000000"
+                origQty: "10.00000000"
+                executedQty: "0.00000000"
+                cummulativeQuoteQty: "0.00000000"
+                status: "CANCELED"
+                timeInForce: "GTC"
+                type: "STOP_LOSS_LIMIT"
+                side: "SELL"
+                stopPrice: "1.00000000"
+              - symbol: "BNBUSDT"
+                origClientOrderId: "TXOvglzXuaubXAaENpaRCB"
+                orderId: 3
+                orderListId: 0
+                clientOrderId: "unfWT8ig8i0uj6lPuYLez6"
+                price: "3.00000000"
+                origQty: "10.00000000"
+                executedQty: "0.00000000"
+                cummulativeQuoteQty: "0.00000000"
+                status: "CANCELED"
+                timeInForce: "GTC"
+                type: "LIMIT_MAKER"
+                side: "SELL"
+      required:
+          - orderListId
+          - contingencyType
+          - listStatusType
+          - listOrderStatus
+          - listClientOrderId
+          - transactionTime
+          - symbol
+          - isIsolated
+          - orders
+          - orderReports
     orderDetails:
       type: object
       properties:
@@ -10475,9 +12327,11 @@ components:
           example: "LTCBTC"
         orderId:
           type: integer
+          format: int64
           example: 1
         orderListId:
           type: integer
+          format: int64
           description: Unless OCO, value will be -1
           example: -1
         clientOrderId:
@@ -10515,15 +12369,36 @@ components:
           example: "0.0"
         time:
           type: integer
+          format: int64
           example: 1499827319559
         updateTime:
           type: integer
+          format: int64
           example: 1499827319559
         isWorking:
           type: boolean
         origQuoteOrderQty:
           type: string
           example: "0.00000000"
+      required:
+          - symbol
+          - orderId
+          - orderListId
+          - clientOrderId
+          - price
+          - origQty
+          - executedQty
+          - cummulativeQuoteQty
+          - status
+          - timeInForce
+          - type
+          - side
+          - stopPrice
+          - icebergQty
+          - time
+          - updateTime
+          - isWorking
+          - origQuoteOrderQty
     orderResponseAck:
       type: object
       properties:
@@ -10532,16 +12407,25 @@ components:
           example: "BTCUSDT"
         orderId: 
           type: integer
+          format: int64
           example: 28
         orderListId: 
           type: integer
+          format: int64
           example: -1
         clientOrderId: 
           type: string
           example: "6gCrw2kRUAF9CvJDGP16IP"
         transactTime: 
           type: integer
+          format: int64
           example: 1507725176595
+      required:
+          - symbol
+          - orderId
+          - orderListId
+          - clientOrderId
+          - transactTime
     orderResponseResult:
       type: object
       properties:
@@ -10550,15 +12434,18 @@ components:
           example: "BTCUSDT"
         orderId: 
           type: integer
+          format: int64
           example: 28
         orderListId: 
           type: integer
+          format: int64
           example: -1
         clientOrderId: 
           type: string
           example: "6gCrw2kRUAF9CvJDGP16IP"
         transactTime: 
           type: integer
+          format: int64
           example: 1507725176595
         price: 
           type: string
@@ -10584,6 +12471,20 @@ components:
         side: 
           type: string
           example: "SELL"
+      required:
+          - symbol
+          - orderId
+          - orderListId
+          - clientOrderId
+          - transactTime
+          - price
+          - origQty
+          - executedQty
+          - cummulativeQuoteQty
+          - status
+          - timeInForce
+          - type
+          - side
     orderResponseFull:
       type: object
       properties:
@@ -10592,15 +12493,18 @@ components:
           example: "BTCUSDT"
         orderId: 
           type: integer
+          format: int64
           example: 28
         orderListId: 
           type: integer
+          format: int64
           example: -1
         clientOrderId: 
           type: string
           example: "6gCrw2kRUAF9CvJDGP16IP"
         transactTime: 
           type: integer
+          format: int64
           example: 1507725176595
         price: 
           type: string
@@ -10643,14 +12547,35 @@ components:
               commissionAsset: 
                 type: string
                 example: "USDT"
+            required:
+                - price
+                - qty
+                - commission
+                - commissionAsset
+      required:
+          - symbol
+          - orderId
+          - orderListId
+          - clientOrderId
+          - transactTime
+          - price
+          - origQty
+          - executedQty
+          - cummulativeQuoteQty
+          - status
+          - timeInForce
+          - type
+          - side
+          - fills
     marginOrder:
       type: object
       properties:
         symbol:
           type: string
-          example: "BNBBTC"
+          example: "LTCBTC"
         orderId:
           type: integer
+          format: int64
           example: 28
         origClientOrderId:
           type: string
@@ -10666,10 +12591,10 @@ components:
           example: "10.00000000"
         executedQty:
           type: string
-          example: "10.00000000"
+          example: "8.00000000"
         cummulativeQuoteQty:
           type: string
-          example: "10.00000000"
+          example: "8.00000000"
         status:
           type: string
           example: "CANCELED"
@@ -10682,6 +12607,19 @@ components:
         side:
           type: string
           example: "SELL"
+      required:
+          - symbol
+          - orderId
+          - origClientOrderId
+          - clientOrderId
+          - price
+          - origQty
+          - executedQty
+          - cummulativeQuoteQty
+          - status
+          - timeInForce
+          - type
+          - side
     marginOrderDetail:
       type: object
       properties:
@@ -10701,6 +12639,7 @@ components:
           type: boolean
         orderId: 
           type: integer
+          format: int64
           example: 213205622
         origQty: 
           type: string
@@ -10724,6 +12663,7 @@ components:
           type: boolean
         time: 
           type: integer
+          format: int64
           example: 1562133008725
         timeInForce: 
           type: string
@@ -10733,7 +12673,26 @@ components:
           example: "LIMIT"
         updateTime: 
           type: integer
+          format: int64
           example: 1562133008725
+      required:
+          - clientOrderId
+          - cummulativeQuoteQty
+          - executedQty
+          - icebergQty
+          - isWorking
+          - orderId
+          - origQty
+          - price
+          - side
+          - status
+          - stopPrice
+          - symbol
+          - isIsolated
+          - time
+          - timeInForce
+          - type
+          - updateTime
     canceledMarginOrderDetail:
       type: object
       properties:
@@ -10747,9 +12706,11 @@ components:
           example: "E6APeyTJvkMvLMYMqu1KQ4"
         orderId:
           type: integer
+          format: int64
           example: 11
         orderListId:
           type: integer
+          format: int64
           example: -1
         clientOrderId:
           type: string
@@ -10778,6 +12739,21 @@ components:
         side:
           type: string
           example: "BUY"
+      required:
+          - symbol
+          - isIsolated
+          - origClientOrderId
+          - orderId
+          - orderListId
+          - clientOrderId
+          - price
+          - origQty
+          - executedQty
+          - cummulativeQuoteQty
+          - status
+          - timeInForce
+          - type
+          - side
     marginOrderResponseAck:
       type: object
       properties:
@@ -10786,6 +12762,7 @@ components:
           example: "BTCUSDT"
         orderId:
           type: integer
+          format: int64
           example: 28
         clientOrderId:
           type: string
@@ -10794,7 +12771,14 @@ components:
           type: boolean
         transactTime:
           type: integer
+          format: int64
           example: 1507725176595
+      required:
+          - symbol
+          - orderId
+          - clientOrderId
+          - isIsolated
+          - transactTime
     marginOrderResponseResult:
       type: object
       properties:
@@ -10803,12 +12787,14 @@ components:
           example: "BTCUSDT"
         orderId:
           type: integer
+          format: int64
           example: 28
         clientOrderId:
           type: string
           example: "6gCrw2kRUAF9CvJDGP16IP"
         transactTime:
           type: integer
+          format: int64
           example: 1507725176595
         price:
           type: string
@@ -10836,6 +12822,20 @@ components:
         side:
           type: string
           example: "SELL"
+      required:
+          - symbol
+          - orderId
+          - clientOrderId
+          - transactTime
+          - price
+          - origQty
+          - executedQty
+          - cummulativeQuoteQty
+          - status
+          - timeInForce
+          - type
+          - isIsolated
+          - side
     marginOrderResponseFull:
       type: object
       properties:
@@ -10844,12 +12844,14 @@ components:
           example: "BTCUSDT"
         orderId:
           type: integer
+          format: int64
           example: 28
         clientOrderId:
           type: string
           example: "6gCrw2kRUAF9CvJDGP16IP"
         transactTime:
           type: integer
+          format: int64
           example: 1507725176595
         price:
           type: string
@@ -10877,7 +12879,7 @@ components:
           example: "SELL"
         marginBuyBorrowAmount:
           type: number
-          format: float
+          format: double
           example: 5
           description: will not return if no margin trade happens
         marginBuyBorrowAsset:
@@ -10903,6 +12905,28 @@ components:
               commissionAsset:
                 type: string
                 example: "USDT"
+            required:
+                - price
+                - qty
+                - commission
+                - commissionAsset
+      required:
+          - symbol
+          - orderId
+          - clientOrderId
+          - transactTime
+          - price
+          - origQty
+          - executedQty
+          - cummulativeQuoteQty
+          - status
+          - timeInForce
+          - type
+          - side
+          - marginBuyBorrowAmount
+          - marginBuyBorrowAsset
+          - isIsolated
+          - fills
     marginTrade:
       type: object
       properties:
@@ -10914,6 +12938,7 @@ components:
           example: "BTC"
         id:
           type: integer
+          format: int64
           example: 28
         isBestMatch:
           type: boolean
@@ -10923,6 +12948,7 @@ components:
           type: boolean
         orderId:
           type: integer
+          format: int64
           example: 28
         price:
           type: string
@@ -10938,7 +12964,21 @@ components:
           example: false
         time:
           type: integer
+          format: int64
           example: 1507725176595
+      required:
+          - commission
+          - commissionAsset
+          - id
+          - isBestMatch
+          - isBuyer
+          - isMaker
+          - orderId
+          - price
+          - qty
+          - symbol
+          - isIsolated
+          - time
     marginTransferDetails:
       type: object
       properties:
@@ -10958,9 +12998,11 @@ components:
                 example: "CONFIRMED"
               timestamp:
                 type: integer
+                format: int64
                 example: 1566898617000
               txId:
                 type: integer
+                format: int64
                 example: 5240372201
               transFrom:
                 type: string
@@ -10968,9 +13010,21 @@ components:
               transTo:
                 type: string
                 example: "ISOLATED_MARGIN"
+            required:
+                - amount
+                - asset
+                - status
+                - timestamp
+                - txId
+                - transFrom
+                - transTo
         total:
           type: integer
+          format: int32
           example: 1
+      required:
+          - rows
+          - total
     isolatedMarginAccountInfo:
       type: object
       properties:
@@ -11010,6 +13064,17 @@ components:
                   totalAsset: 
                     type: string
                     example: "0.00000000"
+                required:
+                    - asset
+                    - borrowEnabled
+                    - borrowed
+                    - free
+                    - interest
+                    - locked
+                    - netAsset
+                    - netAssetOfBtc
+                    - repayEnabled
+                    - totalAsset
               quoteAsset: 
                 type: object
                 properties: 
@@ -11041,6 +13106,17 @@ components:
                   totalAsset: 
                     type: string
                     example: "0.00000000"
+                required:
+                    - asset
+                    - borrowEnabled
+                    - borrowed
+                    - free
+                    - interest
+                    - locked
+                    - netAsset
+                    - netAssetOfBtc
+                    - repayEnabled
+                    - totalAsset
               symbol: 
                 type: string
                 example: "BTCUSDT"
@@ -11070,6 +13146,19 @@ components:
                 example: "1.00000000"
               tradeEnabled: 
                 type: boolean
+            required:
+                - baseAsset
+                - quoteAsset
+                - symbol
+                - isolatedCreated
+                - enabled
+                - marginLevel
+                - marginLevelStatus
+                - marginRatio
+                - indexPrice
+                - liquidatePrice
+                - liquidateRate
+                - tradeEnabled
         totalAssetOfBtc: 
           type: string
           example: "0.00000000"
@@ -11079,6 +13168,11 @@ components:
         totalNetAssetOfBtc: 
           type: string
           example: "0.00000000"
+      required:
+          - assets
+          - totalAssetOfBtc
+          - totalLiabilityOfBtc
+          - totalNetAssetOfBtc
     bookTickerList:
       type: array
       items:
@@ -11101,6 +13195,12 @@ components:
         askQty:
           type: string
           example: "12.56000000"
+      required:
+          - symbol
+          - bidPrice
+          - bidQty
+          - askPrice
+          - askQty
     priceTickerList:
       type: array
       items:
@@ -11114,6 +13214,9 @@ components:
         price:
           type: string
           example: "0.17160000"
+      required:
+          - symbol
+          - price
     tickerList:
       type: array
       items:
@@ -11165,19 +13268,44 @@ components:
           example: "27431289.14792300"
         openTime:
           type: integer
+          format: int64
           example: 1592808788637
         closeTime:
           type: integer
+          format: int64
           example: 1592895188637
         firstId:
           type: integer
+          format: int64
           example: 62683296
         lastId:
           type: integer
+          format: int64
           example: 62739253
         count:
           type: integer
+          format: int64
           example: 55958
+      required:
+          - symbol
+          - priceChange
+          - priceChangePercent
+          - prevClosePrice
+          - lastPrice
+          - bidPrice
+          - bidQty
+          - askPrice
+          - askQty
+          - openPrice
+          - highPrice
+          - lowPrice
+          - volume
+          - quoteVolume
+          - openTime
+          - closeTime
+          - firstId
+          - lastId
+          - count
     myTrade:
       type: object
       properties:
@@ -11186,13 +13314,16 @@ components:
           example: "BNBBTC"
         id:
           type: integer
+          format: int64
           description: Trade id
           example: 28457
         orderId:
           type: integer
+          format: int64
           example: 100234
         orderListId:
           type: integer
+          format: int64
           example:  -1
         price:
           type: string
@@ -11214,6 +13345,7 @@ components:
           example: "BNB"
         time:
           type: integer
+          format: int64
           description: Trade timestamp
           example: 1499865549590
         isBuyer:
@@ -11224,18 +13356,36 @@ components:
           example: false
         isBestMatch:
           type: boolean
+      required:
+          - symbol
+          - id
+          - orderId
+          - orderListId
+          - price
+          - qty
+          - quoteQty
+          - commission
+          - commissionAsset
+          - time
+          - isBuyer
+          - isMaker
+          - isBestMatch
     transaction:
       type: object
       properties:
         tranId:
           type: integer
+          format: int64
           description: transaction id
           example: 345196462
+      required:
+          - tranId
     trade:
       type: object
       properties:
         id:
           type: integer
+          format: int64
           description: trade id
           example: 345196462
         price:
@@ -11252,17 +13402,27 @@ components:
           example: "0.02077200"
         time:
           type: integer
+          format: int64
           description: Trade executed timestamp, as same as `T` in the stream
           example: 1592887772684
         isBuyerMaker:
           type: boolean
         isBestMatch:
           type: boolean
+      required:
+          - id
+          - price
+          - qty
+          - quoteQty
+          - time
+          - isBuyerMaker
+          - isBestMatch
     aggTrade:
       type: object
       properties:
         a:
           type: integer
+          format: int64
           description: Aggregate tradeId
           example: 26129
         p:
@@ -11275,10 +13435,12 @@ components:
           example: "4.70443515"
         f:
           type: integer
+          format: int64
           description: First tradeId
           example: 27781
         l:
           type: integer
+          format: int64
           description: Last tradeId
           example: 27781
         T:
@@ -11291,6 +13453,15 @@ components:
         M:
           type: boolean
           description: Was the trade the best price match?
+      required:
+          - a
+          - p
+          - q
+          - f
+          - l
+          - T
+          - m
+          - M
     bnbBurnStatus:
       type: object
       properties:
@@ -11299,11 +13470,15 @@ components:
         interestBNBBurn:
           type: boolean
           example: false
+      required:
+          - spotBNBBurn
+          - interestBNBBurn
     snapshotSpot:
       type: object
       properties:
         code:
           type: integer
+          format: int64
           example: 200
         msg:
           type: string
@@ -11330,20 +13505,37 @@ components:
                         locked:
                           type: string
                           example: "0.001"
+                      required:
+                          - asset
+                          - free
+                          - locked
                   totalAssetOfBtc:
                     type: string
                     example: "0.09905021"
+                required:
+                    - balances
+                    - totalAssetOfBtc
               type:
                 type: string
                 example: "spot"
               updateTime:
                 type: integer
+                format: int64
                 example: 1576281599000
+            required:
+                - data
+                - type
+                - updateTime
+      required:
+          - code
+          - msg
+          - snapshotVos
     snapshotMargin:
       type: object
       properties:
         code: 
           type: integer
+          format: int64
           example: 200
         msg: 
           type: string
@@ -11391,17 +13583,40 @@ components:
                         netAsset: 
                           type: string
                           example: "1.00000000"
+                      required:
+                          - asset
+                          - borrowed
+                          - free
+                          - interest
+                          - locked
+                          - netAsset
+                required:
+                    - marginLevel
+                    - totalAssetOfBtc
+                    - totalLiabilityOfBtc
+                    - totalNetAssetOfBtc
+                    - userAssets
               type: 
                 type: string
                 example: "margin"
               updateTime: 
                 type: integer
+                format: int64
                 example: 1576281599000
+            required:
+                - data
+                - type
+                - updateTime
+      required:
+          - code
+          - msg
+          - snapshotVos
     snapshotFutures:
       type: object
       properties:
         code: 
           type: integer
+          format: int64
           example: 200
         msg: 
           type: string
@@ -11428,6 +13643,10 @@ components:
                         walletBalance: 
                           type: string
                           example: "120.23811389"
+                      required:
+                          - asset
+                          - marginBalance
+                          - walletBalance
                   position: 
                     type: array
                     items: 
@@ -11448,12 +13667,30 @@ components:
                         unRealizedProfit: 
                           type: string
                           example: "1.24029054"
+                      required:
+                          - entryPrice
+                          - markPrice
+                          - positionAmt
+                          - symbol
+                          - unRealizedProfit
+                required:
+                    - assets
+                    - position
               type: 
                 type: string
                 example: "futures"
               updateTime: 
                 type: integer
+                format: int64
                 example: 1576281599000
+            required:
+                - data
+                - type
+                - updateTime
+      required:
+          - code
+          - msg
+          - snapshotVos
     subAccountUSDTFuturesDetails:
       type: object
       properties: 
@@ -11495,6 +13732,16 @@ components:
                   walletBalance: 
                     type: string
                     example: "0.88308000"
+                required:
+                    - asset
+                    - initialMargin
+                    - maintenanceMargin
+                    - marginBalance
+                    - maxWithdrawAmount
+                    - openOrderInitialMargin
+                    - positionInitialMargin
+                    - unrealizedProfit
+                    - walletBalance
             canDeposit: 
               type: boolean
             canTrade: 
@@ -11503,6 +13750,7 @@ components:
               type: boolean
             feeTier: 
               type: integer
+              format: int64
               example: 2
             maxWithdrawAmount: 
               type: string
@@ -11530,7 +13778,26 @@ components:
               example: "0.88308000"
             updateTime: 
               type: integer
+              format: int64
               example: 1576756674610
+          required:
+              - email
+              - assets
+              - canDeposit
+              - canTrade
+              - canWithdraw
+              - feeTier
+              - maxWithdrawAmount
+              - totalInitialMargin
+              - totalMaintenanceMargin
+              - totalMarginBalance
+              - totalOpenOrderInitialMargin
+              - totalPositionInitialMargin
+              - totalUnrealizedProfit
+              - totalWalletBalance
+              - updateTime
+      required:
+          - futureAccountResp
     subAccountCOINFuturesDetails:
       type: object
       properties: 
@@ -11569,6 +13836,16 @@ components:
               walletBalance: 
                 type: string
                 example: "0.88308000"
+            required:
+                - asset
+                - initialMargin
+                - maintenanceMargin
+                - marginBalance
+                - maxWithdrawAmount
+                - openOrderInitialMargin
+                - positionInitialMargin
+                - unrealizedProfit
+                - walletBalance
         canDeposit: 
           type: boolean
         canTrade: 
@@ -11577,10 +13854,20 @@ components:
           type: boolean
         feeTier: 
           type: integer
+          format: int64
           example: 2
         updateTime: 
           type: integer
+          format: int64
           example: 1598959682001
+      required:
+          - email
+          - assets
+          - canDeposit
+          - canTrade
+          - canWithdraw
+          - feeTier
+          - updateTime
     subAccountUSDTFuturesSummary:
       type: object
       properties: 
@@ -11645,6 +13932,28 @@ components:
                     type: string
                     example: "USD"
                     description: The sum of BUSD and USDT
+                required:
+                    - email
+                    - totalInitialMargin
+                    - totalMaintenanceMargin
+                    - totalMarginBalance
+                    - totalOpenOrderInitialMargin
+                    - totalPositionInitialMargin
+                    - totalUnrealizedProfit
+                    - totalWalletBalance
+                    - asset
+          required:
+              - totalInitialMargin
+              - totalMaintenanceMargin
+              - totalMarginBalance
+              - totalOpenOrderInitialMargin
+              - totalPositionInitialMargin
+              - totalUnrealizedProfit
+              - totalWalletBalance
+              - asset
+              - subAccountList
+      required:
+          - futureAccountSummaryResp
     subAccountCOINFuturesSummary:
       type: object
       properties: 
@@ -11683,6 +13992,20 @@ components:
                   asset: 
                     type: string
                     example: BTC
+                required:
+                    - email
+                    - totalMarginBalance
+                    - totalUnrealizedProfit
+                    - totalWalletBalance
+                    - asset
+          required:
+              - totalMarginBalanceOfBTC
+              - totalUnrealizedProfitOfBTC
+              - totalWalletBalanceOfBTC
+              - asset
+              - subAccountList
+      required:
+          - deliveryAccountSummaryResp
     subAccountUSDTFuturesPositionRisk:
       type: object
       properties: 
@@ -11717,6 +14040,17 @@ components:
               unrealizedProfit: 
                 type: string
                 example: "-0.01612295"
+            required:
+                - entryPrice
+                - leverage
+                - maxNotional
+                - liquidationPrice
+                - markPrice
+                - positionAmount
+                - symbol
+                - unrealizedProfit
+      required:
+          - futurePositionRiskVos
     subAccountCOINFuturesPositionRisk:
       type: object
       properties: 
@@ -11758,6 +14092,20 @@ components:
               unrealizedProfit: 
                 type: string
                 example: "-0.01612295"
+            required:
+                - entryPrice
+                - markPrice
+                - leverage
+                - isolated
+                - isolatedWallet
+                - isolatedMargin
+                - isAutoAddMargin
+                - positionSide
+                - positionAmount
+                - symbol
+                - unrealizedProfit
+      required:
+          - deliveryPositionRiskVos
     savingsFlexiblePurchaseRecord:
       type: array
       items:
@@ -11771,6 +14119,7 @@ components:
             example: "USDT"
           createTime:
             type: integer
+            format: int64
             example: 1575018510000
           lendingType:
             type: string
@@ -11780,10 +14129,19 @@ components:
             example: "USDT"
           purchaseId:
             type: integer
+            format: int64
             example: 26055
           status:
             type: string
             example: "SUCCESS"
+        required:
+            - amount
+            - asset
+            - createTime
+            - lendingType
+            - productName
+            - purchaseId
+            - status
     savingsFixedActivityPurchaseRecord:
       type: array
       items:
@@ -11797,22 +14155,34 @@ components:
             example: "USDT"
           createTime:
             type: integer
+            format: int64
             example: 1575018453000
           lendingType:
             type: string
             example: "ACTIVITY"
           lot:
             type: integer
+            format: int64
             example: 1
           productName:
             type: string
             example: "【Special】USDT 7D (8%)"
           purchaseId:
             type: integer
+            format: int64
             example: 36857
           status:
             type: string
             example: "SUCCESS"
+        required:
+            - amount
+            - asset
+            - createTime
+            - lendingType
+            - lot
+            - productName
+            - purchaseId
+            - status
     savingsFlexibleRedemptionRecord:
       type: array
       items:
@@ -11826,6 +14196,7 @@ components:
             example: "USDT"
           createTime:
             type: integer
+            format: int64
             example: 1577257222000
           principal:
             type: string
@@ -11842,6 +14213,15 @@ components:
           type:
             type: string
             example: "FAST"
+        required:
+            - amount
+            - asset
+            - createTime
+            - principal
+            - projectId
+            - projectName
+            - status
+            - type
     savingsFixedActivityRedemptionRecord:
       type: array
       items:
@@ -11855,6 +14235,7 @@ components:
             example: "USDT"
           createTime:
             type: integer
+            format: int64
             example: 1566200161000
           interest:
             type: string
@@ -11870,20 +14251,155 @@ components:
             example: "USDT 1 day (10% annualized)"
           startTime:
             type: integer
+            format: int64
             example: 1566198000000
           status:
             type: string
             example: "PAID"
+        required:
+            - amount
+            - asset
+            - createTime
+            - interest
+            - principal
+            - projectId
+            - projectName
+            - startTime
+            - status
+    bswapAddLiquidityPreviewCombination:
+      type: object
+      properties:
+        quoteAsset: 
+          type: string
+          example: "USDT"
+        baseAsset: 
+          type: string
+          example: "BUSD"
+        quoteAmt: 
+          type: integer
+          format: int64
+          example: 300000
+        baseAmt: 
+          type: integer
+          format: int64
+          example: 299975
+        price: 
+          type: number
+          format: double
+          example: 1.00008334
+        share: 
+          type: number
+          format: double
+          example: 1.23
+      required:
+          - quoteAsset
+          - baseAsset
+          - quoteAmt
+          - baseAmt
+          - price
+          - share
+    bswapAddLiquidityPreviewSingle:
+      type: object
+      properties:
+        quoteAsset: 
+          type: string
+          example: "USDT"
+        quoteAmt: 
+          type: integer
+          format: int64
+          example: 300000
+        price: 
+          type: number
+          format: double
+          example: 1.00008334
+        share: 
+          type: number
+          format: double
+          example: 1.23
+        slippage: 
+          type: number
+          format: double
+          example: 0.00007245
+        fee: 
+          type: number
+          format: double
+          example: 120
+      required:
+          - quoteAsset
+          - quoteAmt
+          - price
+          - share
+          - slippage
+          - fee
+    bswapRmvLiquidityPreviewCombination:
+      type: object
+      properties:
+        quoteAsset: 
+          type: string
+          example: "USDT"
+        baseAsset: 
+          type: string
+          example: "BUSD"
+        quoteAmt: 
+          type: integer
+          format: int64
+          example: 300000
+        baseAmt: 
+          type: integer
+          format: int64
+          example: 299975
+        price: 
+          type: number
+          format: double
+          example: 1.00008334
+      required:
+          - quoteAsset
+          - baseAsset
+          - quoteAmt
+          - baseAmt
+          - price
+    bswapRmvLiquidityPreviewSingle:
+      type: object
+      properties:
+        quoteAsset: 
+          type: string
+          example: "USDT"
+        quoteAmt: 
+          type: integer
+          format: int64
+          example: 300000
+        price: 
+          type: number
+          format: double
+          example: 1.00008334
+        slippage: 
+          type: number
+          format: double
+          example: 0.00007245
+        fee: 
+          type: number
+          format: double
+          example: 120
+      required:
+          - quoteAsset
+          - quoteAmt
+          - price
+          - slippage
+          - fee
     error:
       type: object
       properties:
         code:
           type: integer
+          format: int64
           description: Error code
         msg:
           type: string
           description: Error message
           example: "error message"
+      required:
+        - code
+        - msg
   securitySchemes:
     ApiKeyAuth:
       name: X-MBX-APIKEY


### PR DESCRIPTION
### Added
- New endpoints for BSwap:
    - `GET /sapi/v1/bswap/poolConfigure` to get pool configure
    - `GET /sapi/v1/bswap/addLiquidityPreview` to calculate expected share amount for adding liquidity in single or dual token
    - `GET /sapi/v1/bswap/removeLiquidityPreview` to calculate expected asset amount of single token redemption or dual token redemption

- Additional properties to specify `array` type: `minItems` and `maxItems`
- Additional format properties to specify `integer` type: `int32` and `int64`
- Additional format properties to specify `number` type: `float` and `double`
- Additional property `required` for response fields