### PR TITLE
Rc-1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.10.0 - 2022-07-19
+
+### Added
+- New endpoint for Market:
+  - `GET /api/v3/ticker` for rolling window price change statistics based on windowSize provided.
+
+- New endpoints for Trade:
+  - `POST /api/v3/order/cancelReplace` to cancel an existing order and place a new order on the same symbol.
+
+- New endpoint for Margin:
+  - `POST /sapi/v3/asset/getUserAsset` to get user assets.
+
+- New endpoint for Wallet:
+  - `GET /sapi/v1/margin/dribblet` to query the historical information of user's margin account small-value asset conversion BNB.
+
+### Changed
+- Update endpoint for Fiat:
+  - `GET /sapi/v1/fiat/orders`: Weight changes from IP(1) to UID(90000)
+
+- Update endpoint for Pay:
+  - `GET /sapi/v1/pay/transactions`: Param names changed: startTimestamp -> startTime; endTimestamp -> endTime.
+
+- Update endpoint for Convert:
+  - `GET /sapi/v1/fiat/orders`: Weight changes from IP(3000) to IP(100)
+
 ## 1.9.0 - 2022-05-23
 
 ### Added

--- a/spot_api.yaml
+++ b/spot_api.yaml
@@ -616,6 +616,116 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+  /api/v3/ticker:
+    get:
+      summary: Rolling window price change statistics
+      description: |-
+        The window used to compute statistics is typically slightly wider than requested windowSize.
+
+        openTime for /api/v3/ticker always starts on a minute, while the closeTime is the current time of the request. As such, the effective window might be up to 1 minute wider than requested.
+
+        E.g. If the closeTime is 1641287867099 (January 04, 2022 09:17:47:099 UTC) , and the windowSize is 1d. the openTime will be: 1641201420000 (January 3, 2022, 09:17:00 UTC)
+
+        Weight(IP): 2 for each requested symbol regardless of windowSize.
+
+        The weight for this request will cap at 100 once the number of symbols in the request is more than 50.
+      tags:
+        - Market
+      parameters:
+        - $ref: '#/components/parameters/optionalSymbol'
+        - $ref: '#/components/parameters/arraySymbols'
+        - name: windowSize
+          in: query
+          description: |-
+            Defaults to 1d if no parameter provided.
+            Supported windowSize values:
+            1m,2m....59m for minutes
+            1h, 2h....23h - for hours
+            1d...7d - for days.
+          
+            Units cannot be combined (e.g. 1d2h is not allowed)
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Rolling price ticker
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  symbol:
+                    type: string
+                    example: BNBBTC
+                  priceChange:
+                    type: string
+                    example: '-8.00000000'
+                  priceChangePercent:
+                    type: string
+                    example: '-88.889'
+                  weightedAvgPrice:
+                    type: string
+                    example: '2.60427807'
+                  openPrice:
+                    type: string
+                    example: '9.00000000'
+                  highPrice:
+                    type: string
+                    example: '9.00000000'
+                  lowPrice:
+                    type: string
+                    example: '1.00000000'
+                  lastPrice:
+                    type: string
+                    example: '1.00000000'
+                  volume:
+                    type: string
+                    example: '187.00000000'
+                  quoteVolume:
+                    type: string
+                    example: '487.00000000'
+                  openTime:
+                    type: integer
+                    format: int64
+                    example: 1641859200000
+                  closeTime:
+                    type: integer
+                    format: int64
+                    example: 1642031999999
+                  firstId:
+                    type: integer
+                    format: int64
+                    example: 0
+                  lastId:
+                    type: integer
+                    format: int64
+                    example: 60
+                  count:
+                    type: integer
+                    format: int64
+                    example: 61
+                required:
+                  - symbol
+                  - priceChange
+                  - priceChangePercent
+                  - weightedAvgPrice
+                  - openPrice
+                  - highPrice
+                  - lowPrice
+                  - lastPrice
+                  - volume
+                  - quoteVolume
+                  - openTime
+                  - closeTime
+                  - firstId
+                  - lastId
+                  - count
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
   /api/v3/order/test:
     post:
       summary: Test New Order (TRADE)
@@ -805,6 +915,215 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+  /api/v3/order/cancelReplace:
+    post:
+      summary: Cancel an Existing Order and Send a New Order (Trade)
+      description: |-
+        Cancels an existing order and places a new order on the same symbol.
+
+        Filters are evaluated before the cancel order is placed.
+
+        If the new order placement is successfully sent to the engine, the order count will increase by 1.
+
+        Weight(IP): 1
+      tags:
+        - Trade
+      parameters:
+        - $ref: '#/components/parameters/symbol'
+        - $ref: '#/components/parameters/side'
+        - $ref: '#/components/parameters/orderType'
+        - name: cancelReplaceMode
+          in: query
+          required: true
+          description: |-
+            - `STOP_ON_FAILURE` If the cancel request fails, the new order placement will not be attempted.
+            - `ALLOW_FAILURES` If new order placement will be attempted even if cancel request fails.
+          schema:
+            type: string
+            example: "STOP_ON_FAILURE"
+        - $ref: '#/components/parameters/timeInForce'
+        - $ref: '#/components/parameters/optionalQuantity'
+        - $ref: '#/components/parameters/quoteOrderQty'
+        - $ref: '#/components/parameters/optionalPrice'
+        - name: cancelNewClientOrderId
+          in: query
+          description: Used to uniquely identify this cancel. Automatically generated by default
+          schema:
+            type: string
+        - name: cancelOrigClientOrderId
+          in: query
+          description: Either the cancelOrigClientOrderId or cancelOrderId must be provided. If both are provided, cancelOrderId takes precedence.
+          schema:
+            type: string
+        - name: cancelOrderId
+          in: query
+          description: Either the cancelOrigClientOrderId or cancelOrderId must be provided. If both are provided, cancelOrderId takes precedence.
+          schema:
+            type: integer
+            format: int64
+            example: 12        
+        - $ref: '#/components/parameters/newClientOrderId'
+        - $ref: '#/components/parameters/stopPrice'
+        - $ref: '#/components/parameters/optionalTrailingDelta'
+        - $ref: '#/components/parameters/icebergQty'
+        - $ref: '#/components/parameters/newOrderRespType'
+        - $ref: '#/components/parameters/recvWindow'
+        - $ref: '#/components/parameters/timestamp'
+        - $ref: '#/components/parameters/signature'
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Operation details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cancelResult:
+                    type: string
+                    example: SUCCESS
+                  newOrderResult:
+                    type: string
+                    example: SUCCESS
+                  cancelResponse:
+                    type: object
+                    properties:
+                      symbol:
+                        type: string
+                        example: BTCUSDT
+                      origClientOrderId:
+                        type: string
+                        example: DnLo3vTAQcjha43lAZhZ0y
+                      orderId:
+                        type: integer
+                        format: int64
+                        example: 9
+                      orderListId:
+                        type: integer
+                        format: int64
+                        example: -1
+                      clientOrderId:
+                        type: string
+                        example: osxN3JXAtJvKvCqGeMWMVR
+                      price:
+                        type: string
+                        example: '0.01000000'
+                      origQty:
+                        type: string
+                        example: '0.000100'
+                      executedQty:
+                        type: string
+                        example: '0.00000000'
+                      cummulativeQuoteQty:
+                        type: string
+                        example: '0.00000000'
+                      status:
+                        type: string
+                        example: CANCELED
+                      timeInForce:
+                        type: string
+                        example: GTC
+                      type:
+                        type: string
+                        example: LIMIT
+                      side:
+                        type: string
+                        example: SELL
+                    required:
+                      - symbol
+                      - origClientOrderId
+                      - orderId
+                      - orderListId
+                      - clientOrderId
+                      - price
+                      - origQty
+                      - executedQty
+                      - cummulativeQuoteQty
+                      - status
+                      - timeInForce
+                      - type
+                      - side
+                  newOrderResponse:
+                    type: object
+                    properties:
+                      symbol:
+                        type: string
+                        example: BTCUSDT
+                      orderId:
+                        type: integer
+                        format: int64
+                        example: 10
+                      orderListId:
+                        type: integer
+                        format: int64
+                        example: -1
+                      clientOrderId:
+                        type: string
+                        example: wOceeeOzNORyLiQfw7jd8S
+                      transactTime:
+                        type: integer
+                        format: int64
+                        example: 1652928801803
+                      price:
+                        type: string
+                        example: '0.02000000'
+                      origQty:
+                        type: string
+                        example: '0.040000'
+                      executedQty:
+                        type: string
+                        example: '0.00000000'
+                      cummulativeQuoteQty:
+                        type: string
+                        example: '0.00000000'
+                      status:
+                        type: string
+                        example: NEW
+                      timeInForce:
+                        type: string
+                        example: GTC
+                      type:
+                        type: string
+                        example: LIMIT
+                      side:
+                        type: string
+                        example: BUY
+                      fills:
+                        type: array
+                        items: null
+                    required:
+                      - symbol
+                      - orderId
+                      - orderListId
+                      - clientOrderId
+                      - transactTime
+                      - price
+                      - origQty
+                      - executedQty
+                      - cummulativeQuoteQty
+                      - status
+                      - timeInForce
+                      - type
+                      - side
+                      - fills
+                required:
+                  - cancelResult
+                  - newOrderResult
+                  - cancelResponse
+                  - newOrderResponse
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+            description: Unauthorized Request
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/error'
   /api/v3/openOrders:
     get:
       summary: Current Open Orders (USER_DATA)
@@ -4252,6 +4571,107 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+  /sapi/v1/margin/dribblet:
+    get:
+      summary: Margin Dustlog (USER_DATA)
+      description: |-
+        Query the historical information of user's margin account small-value asset conversion BNB.
+
+        Weight(IP): 1
+      tags:
+        - Margin
+      parameters:
+        - $ref: '#/components/parameters/startTime'
+        - $ref: '#/components/parameters/endTime'
+        - $ref: '#/components/parameters/recvWindow'
+        - $ref: '#/components/parameters/timestamp'
+        - $ref: '#/components/parameters/signature'
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Dust Log
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    format: int64
+                    example: 8
+                  userAssetDribblets:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        operateTime:
+                          type: integer
+                          format: int64
+                          example: 1615985535000
+                        totalTransferedAmount:
+                          type: string
+                          example: '0.00132256'
+                        totalServiceChargeAmount:
+                          type: string
+                          example: '0.00002699'
+                        transId:
+                          type: integer
+                          format: int64
+                          example: 45178372831
+                        userAssetDribbletDetails:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              transId:
+                                type: integer
+                                format: int64
+                                example: 4359321
+                              serviceChargeAmount:
+                                type: string
+                                example: '0.000009'
+                              amount:
+                                type: string
+                                example: '0.0009'
+                              operateTime:
+                                type: integer
+                                format: int64
+                                example: 1615985535000
+                              transferedAmount:
+                                type: string
+                                example: '0.000441'
+                              fromAsset:
+                                type: string
+                                example: USDT
+                            required:
+                              - transId
+                              - serviceChargeAmount
+                              - amount
+                              - operateTime
+                              - transferedAmount
+                              - fromAsset
+                      required:
+                        - operateTime
+                        - totalTransferedAmount
+                        - totalServiceChargeAmount
+                        - transId
+                        - userAssetDribbletDetails
+                required:
+                  - total
+                  - userAssetDribblets
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
   /sapi/v1/system/status:
     get:
       summary: System Status (System)
@@ -5747,11 +6167,7 @@ paths:
         - Wallet
       parameters:
         - $ref: '#/components/parameters/optionalAsset'
-        - name: needBtcValuation
-          in: query
-          schema:
-            type: string
-            enum: ['true','false']
+        - $ref: '#/components/parameters/needBtcValuation'
         - $ref: '#/components/parameters/recvWindow'
         - $ref: '#/components/parameters/timestamp'
         - $ref: '#/components/parameters/signature'
@@ -5792,6 +6208,74 @@ paths:
                       - freeze
                       - withdrawing
                       - btcValuation
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+  /sapi/v3/asset/getUserAsset:
+    post:
+      summary: User Asset (USER_DATA)
+      description: |-
+        Get user assets, just for positive data.
+
+        Weight(IP): 5
+      tags:
+        - Wallet
+      parameters:
+        - $ref: '#/components/parameters/optionalAsset'
+        - $ref: '#/components/parameters/needBtcValuation'
+        - $ref: '#/components/parameters/recvWindow'
+        - $ref: '#/components/parameters/timestamp'
+        - $ref: '#/components/parameters/signature'
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: User assets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    asset:
+                      type: string
+                      example: AVAX
+                    free:
+                      type: string
+                      example: '1'
+                    locked:
+                      type: string
+                      example: '0'
+                    freeze:
+                      type: string
+                      example: '0'
+                    withdrawing:
+                      type: string
+                      example: '0'
+                    ipoable:
+                      type: string
+                      example: '0'
+                    btcValuation:
+                      type: string
+                      example: '0'
+                  required:
+                    - asset
+                    - free
+                    - locked
+                    - freeze
+                    - withdrawing
+                    - ipoable
+                    - btcValuation
         '400':
           description: Bad Request
           content:
@@ -8485,7 +8969,7 @@ paths:
       description: |-
         - If beginTime and endTime are not sent, the recent 30-day data will be returned.
         
-        Weight(IP): 1
+        Weight(UID): 90000
       tags:
         - Fiat
       parameters:
@@ -13026,26 +13510,16 @@ paths:
     get:
       summary: Get Pay Trade History (USER_DATA)
       description: |-
-        - If startTimestamp and endTimestamp are not sent, the recent 90 days' data will be returned.
-        - The max interval between startTimestamp and endTimestamp is 90 days.
+        - If startTime and endTime are not sent, the recent 90 days' data will be returned.
+        - The max interval between startTime and endTime is 90 days.
         - Support for querying orders within the last 18 months.
         
         Weight(UID): 3000
       tags:
         - Pay
-      parameters:
-        - name: startTimestamp
-          in: query
-          description: UTC timestamp in ms
-          schema:
-            type: integer
-            format: int64
-        - name: endTimestamp
-          in: query
-          description: UTC timestamp in ms
-          schema:
-            type: integer
-            format: int64
+      parameters:        
+        - $ref: '#/components/parameters/startTime'
+        - $ref: '#/components/parameters/endTime'
         - name: limit
           in: query
           description: "default 100, max 100"
@@ -13144,7 +13618,7 @@ paths:
       description: |-
         - The max interval between startTime and endTime is 30 days.
 
-        Weight(UID): 3000
+        Weight(UID): 100
       tags:
         - Convert
       parameters:
@@ -14424,6 +14898,12 @@ components:
       required: true
       schema:
         type: string
+    needBtcValuation:
+      name: needBtcValuation
+      in: query
+      schema:
+        type: string
+        enum: ['true','false']
     lendingType:
       name: lendingType
       in: query


### PR DESCRIPTION
New endpoint for Market:
- `GET /api/v3/ticker` for rolling window price change statistics based on windowSize provided.

New endpoint for Trade:
- `POST /api/v3/order/cancelReplace` to cancel an existing order and place a new order on the same symbol.

Update endpoint for Fiat:
- `GET /sapi/v1/fiat/orders`: Weight changes from IP(1) to UID(90000)

Update endpoint for Pay:
- `GET /sapi/v1/pay/transactions`: Param names changed: startTimestamp -> startTime; endTimestamp -> endTime.

New endpoint for Margin:
  - `POST /sapi/v3/asset/getUserAsset` to get user assets.

New endpoint for Wallet:
  - `GET /sapi/v1/margin/dribblet` to query the historical information of user's margin account small-value asset conversion BNB.

Update endpoint for Convert:
  - `GET /sapi/v1/fiat/orders`: Weight changes from IP(3000) to IP(100)