### PR TITLE
Updated spot_api.yaml

### DIFF
--- a/spot_api.yaml
+++ b/spot_api.yaml
@@ -17765,7 +17765,7 @@ paths:
 
         - You have a Binance account
         - You have passed kyc
-        - You have a sufﬁcient balance in your Binance funding wallet
+        - You have a sufficient balance in your Binance funding wallet
         - You need Enable Withdrawals for the API Key which requests this endpoint.
 
         Daily creation volume: 2 BTC / 24H Daily creation times: 200 Codes / 24H
@@ -18055,7 +18055,7 @@ paths:
         To get started with, please make sure:
         - You have a Binance account
         - You have passed kyc
-        - You have a sufﬁcient balance in your Binance funding wallet
+        - You have a sufficient balance in your Binance funding wallet
         - You need Enable Withdrawals for the API Key which requests this endpoint.
 
         Daily creation volume: 2 BTC / 24H Daily creation times: 200 Codes / 24H


### PR DESCRIPTION
Updated the description of /sapi/v1/giftcard/buyCode and /sapi/v1/giftcard/createCode. The word "sufﬁcient" was written with a special character. Because of this compilation of generated client failed with
"error: unmappable character (0x81) for encoding windows-1252".